### PR TITLE
feat: support for multiple authors on articles

### DIFF
--- a/app/components/error-message/_styles.module.css
+++ b/app/components/error-message/_styles.module.css
@@ -4,7 +4,7 @@
   align-items: start;
   justify-content: start;
   gap: 4px;
-  color: var(--admin-error);
+  color: var(--error);
   font-weight: var(--font-weight-medium);
   font-size: var(--font-size-sm);
 }

--- a/app/components/fieldset/_styles.module.css
+++ b/app/components/fieldset/_styles.module.css
@@ -1,22 +1,22 @@
 .fieldset {
   position: relative;
   width: 100%;
-  border: 2px solid var(--admin-border);
+  border: 2px solid var(--border);
   border-radius: 8px;
   padding: 16px;
   margin: 0;
-  background-color: var(--admin-bg-primary);
+  background-color: var(--bg-primary);
   transition: border-color 0.15s ease;
 
   &:focus-within {
-    border-color: var(--admin-purple);
+    border-color: var(--violet);
   }
 }
 
 .legend {
   font-size: var(--font-size-md);
   font-weight: var(--font-weight-semibold);
-  color: var(--admin-text-primary);
+  color: var(--text-primary);
   margin: 0;
   padding: 0 8px;
 }

--- a/app/components/file-input/_styles.module.css
+++ b/app/components/file-input/_styles.module.css
@@ -9,27 +9,27 @@
 .fileArea {
   display: grid;
   grid-template-rows: 1fr min-content;
-  border: 2px solid var(--admin-border);
+  border: 2px solid var(--border);
   border-radius: 8px;
   width: 100%;
   max-width: 600px;
   padding: 36px 36px 12px 36px;
   justify-items: start;
-  background-color: var(--admin-bg-primary);
+  background-color: var(--bg-primary);
   transition:
     border-color 0.15s ease,
     box-shadow 0.15s ease;
 
   &:focus-within {
-    border-color: var(--admin-purple);
-    box-shadow: var(--admin-focus-shadow);
+    border-color: var(--violet);
+    box-shadow: var(--focus-shadow);
   }
 }
 
 .inputArea {
   display: grid;
   grid-template-areas: "input";
-  border: 2px dashed var(--admin-border);
+  border: 2px dashed var(--border);
   border-radius: 8px;
   margin-bottom: 8px;
   width: 100%;
@@ -37,11 +37,11 @@
   max-height: 30dvh;
   justify-items: stretch;
   align-items: stretch;
-  background-color: var(--admin-bg-secondary);
+  background-color: var(--bg-secondary);
   transition: border-color 0.15s ease;
 
   &:hover {
-    border-color: var(--admin-border-hover);
+    border-color: var(--border-hover);
   }
 }
 
@@ -61,11 +61,11 @@
   align-items: center;
   justify-self: center;
   align-self: center;
-  color: var(--admin-text-tertiary);
+  color: var(--text-tertiary);
 }
 
 .inputDataSet {
-  color: var(--admin-text-primary);
+  color: var(--text-primary);
 }
 
 .fileName {
@@ -75,7 +75,7 @@
 }
 
 .fileNameSet {
-  color: var(--admin-text-primary);
+  color: var(--text-primary);
 }
 
 .fileIcon {

--- a/app/components/label/_styles.module.css
+++ b/app/components/label/_styles.module.css
@@ -1,5 +1,5 @@
 .label {
-  color: var(--admin-text-primary);
+  color: var(--text-primary);
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-semibold);
   line-height: var(--line-height-sm);

--- a/app/components/select/_styles.module.css
+++ b/app/components/select/_styles.module.css
@@ -7,58 +7,61 @@
 }
 
 .select {
-  /* Colors */
-  color: var(--admin-text-primary);
-  background-color: var(--admin-bg-primary);
-  border: 2px solid var(--admin-border);
+  @layer component {
+    /* Colors */
+    color: var(--text-primary);
+    background-color: var(--bg-primary);
+    border: 2px solid var(--border);
 
-  /* Typography - use global tokens directly */
-  font-size: var(--font-size-md);
-  font-weight: var(--font-weight-regular);
-  line-height: var(--line-height-md);
+    /* Typography - use global tokens directly */
+    font-family: var(--font-family), sans-serif;
+    font-size: var(--font-size-md);
+    font-weight: var(--font-weight-regular);
+    line-height: var(--line-height-md);
 
-  /* Layout */
-  padding-block: 12px;
-  padding-inline: 16px;
-  border-radius: 8px;
-  width: 100%;
-  max-width: 400px;
+    /* Layout */
+    padding-block: 12px;
+    padding-inline: 16px;
+    border-radius: 8px;
+    width: 100%;
+    max-width: 400px;
 
-  /* Transitions */
-  transition:
-    border-color 150ms ease-out,
-    box-shadow 150ms ease-out,
-    background-color 150ms ease-out;
+    /* Transitions */
+    transition:
+      border-color 150ms ease-out,
+      box-shadow 150ms ease-out,
+      background-color 150ms ease-out;
 
-  cursor: pointer;
+    cursor: pointer;
 
-  /* Hover State */
-  &:hover:not(:disabled):not(:focus-visible) {
-    border-color: var(--admin-border-hover);
-  }
+    /* Hover State */
+    &:hover:not(:disabled):not(:focus-visible) {
+      border-color: var(--border-hover);
+    }
 
-  /* Focus Visible State (keyboard navigation only) */
-  &:focus-visible {
-    border-color: var(--admin-purple);
-    box-shadow: var(--admin-focus-shadow);
-    outline: none;
-  }
+    /* Focus Visible State (keyboard navigation only) */
+    &:focus-visible {
+      border-color: var(--violet);
+      box-shadow: var(--focus-shadow);
+      outline: none;
+    }
 
-  /* Disabled State */
-  &:disabled {
-    background-color: var(--admin-bg-disabled);
-    color: var(--admin-text-tertiary);
-    cursor: not-allowed;
-    opacity: 0.7;
+    /* Disabled State */
+    &:disabled {
+      background-color: var(--bg-disabled);
+      color: var(--text-tertiary);
+      cursor: not-allowed;
+      opacity: 0.7;
+    }
   }
 }
 
 /* Error State */
 .select.selectError {
-  border-color: var(--admin-error);
+  border-color: var(--error);
 
   &:focus-visible {
-    border-color: var(--admin-error);
-    box-shadow: var(--admin-focus-shadow-error);
+    border-color: var(--error);
+    box-shadow: var(--focus-shadow-error);
   }
 }

--- a/app/routes/administration/_index/route.tsx
+++ b/app/routes/administration/_index/route.tsx
@@ -82,7 +82,7 @@ export default function RouteComponent({ loaderData }: Route.ComponentProps) {
           <div className={styles.pendingList}>
             {pendingReviewItems.articles.map((article) => (
               <AdminPendingItem
-                author={article.author.name}
+                author={article.authors.map((a) => a.name).join(', ')}
                 date={new Date(article.createdAt)}
                 key={article.id}
                 title={article.title}

--- a/app/routes/administration/_index/utils/get-pending-articles.server.ts
+++ b/app/routes/administration/_index/utils/get-pending-articles.server.ts
@@ -10,11 +10,13 @@ export async function getPendingArticles(options: GetPendingArticlesOptions) {
   const { currentAuthorId, currentRoleLevel } = options
 
   const where: Prisma.ArticleWhereInput = {
-    author:
+    authors:
       currentRoleLevel === 1
-        ? undefined
-        : { role: { level: { gt: currentRoleLevel } } },
-    authorId: { not: currentAuthorId },
+        ? { none: { id: currentAuthorId } }
+        : {
+            none: { id: currentAuthorId },
+            every: { role: { level: { gt: currentRoleLevel } } },
+          },
     state: 'draft',
   }
 
@@ -22,7 +24,7 @@ export async function getPendingArticles(options: GetPendingArticlesOptions) {
     prisma.article.findMany({
       orderBy: { createdAt: 'desc' },
       select: {
-        author: { select: { name: true } },
+        authors: { select: { name: true } },
         createdAt: true,
         id: true,
         title: true,

--- a/app/routes/administration/_index/utils/get-pending-articles.server.ts
+++ b/app/routes/administration/_index/utils/get-pending-articles.server.ts
@@ -14,8 +14,8 @@ export async function getPendingArticles(options: GetPendingArticlesOptions) {
       currentRoleLevel === 1
         ? { none: { id: currentAuthorId } }
         : {
-            none: { id: currentAuthorId },
             every: { role: { level: { gt: currentRoleLevel } } },
+            none: { id: currentAuthorId },
           },
     state: 'draft',
   }

--- a/app/routes/administration/archive/issue/_index/_action.ts
+++ b/app/routes/administration/archive/issue/_index/_action.ts
@@ -33,18 +33,23 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     where: { id: issueId },
   })
 
+  const target = {
+    authorIds: [currentIssue.authorId],
+    state: currentIssue.state,
+  }
+
   switch (intent) {
     case INTENT_VALUE.archive:
       await archiveIssue(request, {
         id: issueId,
-        target: currentIssue,
+        target,
       })
       break
 
     case INTENT_VALUE.delete:
       await deleteIssue(request, {
         id: issueId,
-        target: currentIssue,
+        target,
       })
 
       if (withRedirect) {
@@ -55,28 +60,28 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     case INTENT_VALUE.publish:
       await publishIssue(request, {
         id: issueId,
-        target: currentIssue,
+        target,
       })
       break
 
     case INTENT_VALUE.restore:
       await restoreIssue(request, {
         id: issueId,
-        target: currentIssue,
+        target,
       })
       break
 
     case INTENT_VALUE.retract:
       await retractIssue(request, {
         id: issueId,
-        target: currentIssue,
+        target,
       })
       break
 
     case INTENT_VALUE.review:
       await reviewIssue(request, {
         id: issueId,
-        target: currentIssue,
+        target,
       })
       break
 

--- a/app/routes/administration/articles/_index/_loader.ts
+++ b/app/routes/administration/articles/_index/_loader.ts
@@ -99,11 +99,20 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
 
   // Compute permissions for each article
   const articles = rawArticles.map((article) => {
+    if (article.authors.length === 0) {
+      return {
+        ...article,
+        canDelete: false,
+        canEdit: false,
+        canView: false,
+      }
+    }
+
     const effectiveTargetAuthorId = article.authors.some(
       (a) => a.id === context.authorId,
     )
       ? context.authorId
-      : (article.authors[0]?.id ?? context.authorId)
+      : article.authors[0].id
 
     return {
       ...article,

--- a/app/routes/administration/articles/_index/_loader.ts
+++ b/app/routes/administration/articles/_index/_loader.ts
@@ -41,7 +41,7 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
         createdAt: 'desc',
       },
       select: {
-        authorId: true,
+        authors: { select: { id: true } },
         id: true,
         state: true,
         title: true,
@@ -53,19 +53,19 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
           {
             state: 'draft',
             ...(draftPerms.hasOwn && !draftPerms.hasAny
-              ? { authorId: context.authorId }
+              ? { authors: { some: { id: context.authorId } } }
               : {}),
           },
           {
             state: 'published',
             ...(publishedPerms.hasOwn && !publishedPerms.hasAny
-              ? { authorId: context.authorId }
+              ? { authors: { some: { id: context.authorId } } }
               : {}),
           },
           {
             state: 'archived',
             ...(archivedPerms.hasOwn && !archivedPerms.hasAny
-              ? { authorId: context.authorId }
+              ? { authors: { some: { id: context.authorId } } }
               : {}),
           },
         ],
@@ -77,19 +77,19 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
           {
             state: 'draft',
             ...(draftPerms.hasOwn && !draftPerms.hasAny
-              ? { authorId: context.authorId }
+              ? { authors: { some: { id: context.authorId } } }
               : {}),
           },
           {
             state: 'published',
             ...(publishedPerms.hasOwn && !publishedPerms.hasAny
-              ? { authorId: context.authorId }
+              ? { authors: { some: { id: context.authorId } } }
               : {}),
           },
           {
             state: 'archived',
             ...(archivedPerms.hasOwn && !archivedPerms.hasAny
-              ? { authorId: context.authorId }
+              ? { authors: { some: { id: context.authorId } } }
               : {}),
           },
         ],
@@ -99,25 +99,31 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
 
   // Compute permissions for each article
   const articles = rawArticles.map((article) => {
+    const effectiveTargetAuthorId = article.authors.some(
+      (a) => a.id === context.authorId,
+    )
+      ? context.authorId
+      : (article.authors[0]?.id ?? context.authorId)
+
     return {
       ...article,
       canDelete: context.can({
         action: 'delete',
         entity: 'article',
         state: article.state,
-        targetAuthorId: article.authorId,
+        targetAuthorId: effectiveTargetAuthorId,
       }).hasPermission,
       canEdit: context.can({
         action: 'update',
         entity: 'article',
         state: article.state,
-        targetAuthorId: article.authorId,
+        targetAuthorId: effectiveTargetAuthorId,
       }).hasPermission,
       canView: context.can({
         action: 'view',
         entity: 'article',
         state: article.state,
-        targetAuthorId: article.authorId,
+        targetAuthorId: effectiveTargetAuthorId,
       }).hasPermission,
     }
   })

--- a/app/routes/administration/articles/add-article/_action.ts
+++ b/app/routes/administration/articles/add-article/_action.ts
@@ -27,7 +27,7 @@ export async function action({ request }: Route.ActionArgs) {
   const {
     title,
     slug,
-    authorId,
+    authorIds,
     categoryIds,
     tagIds,
     images,
@@ -37,7 +37,7 @@ export async function action({ request }: Route.ActionArgs) {
   } = submission.value
 
   const { articleId } = await createArticle(request, {
-    authorId,
+    authorIds,
     categoryIds,
     content,
     excerpt,

--- a/app/routes/administration/articles/add-article/_schema.ts
+++ b/app/routes/administration/articles/add-article/_schema.ts
@@ -17,7 +17,9 @@ const newImageSchema = z.object({
 })
 
 export const schema = z.object({
-  authorId: z.string({ error: 'Autor je povinný' }),
+  authorIds: z
+    .array(z.string())
+    .min(1, { message: 'Alespoň jeden autor je povinný' }),
   categoryIds: z.array(z.string()).optional(),
   content: z.string({ error: 'Obsah je povinný' }),
   excerpt: z.string().optional(),

--- a/app/routes/administration/articles/add-article/_schema.ts
+++ b/app/routes/administration/articles/add-article/_schema.ts
@@ -18,7 +18,7 @@ const newImageSchema = z.object({
 
 export const schema = z.object({
   authorIds: z
-    .array(z.string())
+    .array(z.string({ error: 'Vyberte autora' }))
     .min(1, { message: 'Alespoň jeden autor je povinný' }),
   categoryIds: z.array(z.string()).optional(),
   content: z.string({ error: 'Obsah je povinný' }),

--- a/app/routes/administration/articles/add-article/_styles.module.css
+++ b/app/routes/administration/articles/add-article/_styles.module.css
@@ -34,3 +34,20 @@
     grid-area: featuredImage;
   }
 }
+
+.authorRow {
+  @layer route {
+    display: flex;
+    align-items: flex-end;
+    gap: 8px;
+    width: 100%;
+
+    & > section {
+      flex: 1;
+    }
+
+    & > button {
+      margin-block-end: 20px;
+    }
+  }
+}

--- a/app/routes/administration/articles/add-article/route.tsx
+++ b/app/routes/administration/articles/add-article/route.tsx
@@ -255,6 +255,7 @@ export default function RouteComponent({
                   errors={authorField.errors}
                   label={'Autor'}
                 >
+                  <option value={''}>— vyberte autora —</option>
                   {loaderData.authors.map((author) => (
                     <option key={author.id} value={author.id}>
                       {author.name}

--- a/app/routes/administration/articles/add-article/route.tsx
+++ b/app/routes/administration/articles/add-article/route.tsx
@@ -264,8 +264,8 @@ export default function RouteComponent({
                 {index > 0 && (
                   <AdminButton
                     {...form.remove.getButtonProps({
-                      name: fields.authorIds.name,
                       index,
+                      name: fields.authorIds.name,
                     })}
                     variant={'danger'}
                   >
@@ -277,8 +277,8 @@ export default function RouteComponent({
             ))}
             <AdminButton
               {...form.insert.getButtonProps({
-                name: fields.authorIds.name,
                 defaultValue: '',
+                name: fields.authorIds.name,
               })}
             >
               Přidat autora

--- a/app/routes/administration/articles/add-article/route.tsx
+++ b/app/routes/administration/articles/add-article/route.tsx
@@ -46,7 +46,7 @@ export default function RouteComponent({
   const [form, fields] = useForm({
     constraint: getZodConstraint(schema),
     defaultValue: {
-      authorId: loaderData.selfAuthorId,
+      authorIds: [loaderData.selfAuthorId],
       featuredImage: FEATURED_IMAGE_SOURCE.NONE,
     },
     id: 'add-article',
@@ -246,19 +246,43 @@ export default function RouteComponent({
 
           <Fieldset
             disabled={isLoadingOrSubmitting}
-            legend={'Informace o autorovi'}
+            legend={'Informace o autorech'}
           >
-            <Select
-              {...getSelectProps(fields.authorId)}
-              errors={fields.authorId.errors}
-              label={'Autor'}
+            {fields.authorIds.getFieldList().map((authorField, index) => (
+              <div className={styles.authorRow} key={authorField.key}>
+                <Select
+                  {...getSelectProps(authorField)}
+                  errors={authorField.errors}
+                  label={'Autor'}
+                >
+                  {loaderData.authors.map((author) => (
+                    <option key={author.id} value={author.id}>
+                      {author.name}
+                    </option>
+                  ))}
+                </Select>
+                {index > 0 && (
+                  <AdminButton
+                    {...form.remove.getButtonProps({
+                      name: fields.authorIds.name,
+                      index,
+                    })}
+                    variant={'danger'}
+                  >
+                    <DeleteIcon className={styles.removeIcon} />
+                    Odstranit
+                  </AdminButton>
+                )}
+              </div>
+            ))}
+            <AdminButton
+              {...form.insert.getButtonProps({
+                name: fields.authorIds.name,
+                defaultValue: '',
+              })}
             >
-              {loaderData.authors.map((author) => (
-                <option key={author.id} value={author.id}>
-                  {author.name}
-                </option>
-              ))}
-            </Select>
+              Přidat autora
+            </AdminButton>
           </Fieldset>
 
           <FormActions>

--- a/app/routes/administration/articles/add-article/utils/create-article.server.ts
+++ b/app/routes/administration/articles/add-article/utils/create-article.server.ts
@@ -11,7 +11,7 @@ type Options = {
   excerpt?: string
   categoryIds?: string[]
   tagIds?: string[]
-  authorId: string
+  authorIds: string[]
   images?: Array<{ file: File; altText: string; description?: string }>
   featuredImage: FeaturedImage
 }
@@ -19,7 +19,7 @@ type Options = {
 export async function createArticle(
   request: Request,
   {
-    authorId,
+    authorIds,
     title,
     slug,
     content,
@@ -34,7 +34,7 @@ export async function createArticle(
   const article = await withAuthorPermission(request, {
     action: 'create',
     entity: 'article',
-    execute: async () => {
+    execute: async (context) => {
       const featuredImageIndex =
         featuredImage.source === 'new' ? featuredImage.index : undefined
 
@@ -58,7 +58,9 @@ export async function createArticle(
 
       const createdArticle = await prisma.article.create({
         data: {
-          authorId,
+          authors: {
+            connect: authorIds.map((id) => ({ id })),
+          },
           categories: {
             connect: categoryIds?.map((id) => ({ id })) || [],
           },
@@ -104,7 +106,7 @@ export async function createArticle(
 
       await prisma.pageSEO.create({
         data: {
-          authorId,
+          authorId: context.authorId,
           description: excerpt || null,
           ogImageUrl,
           pathname,
@@ -116,7 +118,7 @@ export async function createArticle(
 
       return createdArticle
     },
-    target: { authorId, state: 'draft' },
+    target: { authorIds, state: 'draft' },
   })
 
   return { articleId: article.id }

--- a/app/routes/administration/articles/article/_index/_action.ts
+++ b/app/routes/administration/articles/article/_index/_action.ts
@@ -29,22 +29,30 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
   const withRedirect = formData.get(REDIRECT_NAME) === 'true'
 
   const currentArticle = await prisma.article.findUniqueOrThrow({
-    select: { authorId: true, state: true },
+    select: {
+      authors: { select: { id: true } },
+      state: true,
+    },
     where: { id: articleId },
   })
+
+  const target = {
+    authorIds: currentArticle.authors.map((author) => author.id),
+    state: currentArticle.state,
+  }
 
   switch (intent) {
     case INTENT_VALUE.archive:
       await archiveArticle(request, {
         id: articleId,
-        target: currentArticle,
+        target,
       })
       break
 
     case INTENT_VALUE.delete:
       await deleteArticle(request, {
         id: articleId,
-        target: currentArticle,
+        target,
       })
 
       if (withRedirect) {
@@ -55,28 +63,28 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     case INTENT_VALUE.publish:
       await publishArticle(request, {
         id: articleId,
-        target: currentArticle,
+        target,
       })
       break
 
     case INTENT_VALUE.restore:
       await restoreArticle(request, {
         id: articleId,
-        target: currentArticle,
+        target,
       })
       break
 
     case INTENT_VALUE.retract:
       await retractArticle(request, {
         id: articleId,
-        target: currentArticle,
+        target,
       })
       break
 
     case INTENT_VALUE.review:
       await reviewArticle(request, {
         id: articleId,
-        target: currentArticle,
+        target,
       })
       break
 

--- a/app/routes/administration/articles/article/_index/_loader.ts
+++ b/app/routes/administration/articles/article/_index/_loader.ts
@@ -88,11 +88,15 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
     throw new Response('Článek nenalezen', { status: 404 })
   }
 
+  if (article.authors.length === 0) {
+    throw new Response('Článek nemá přiřazeného autora', { status: 500 })
+  }
+
   const effectiveTargetAuthorId = article.authors.some(
     (author) => author.id === context.authorId,
   )
     ? context.authorId
-    : (article.authors[0]?.id ?? context.authorId)
+    : article.authors[0].id
 
   // Check view permission
   const { hasPermission: canView } = context.can({
@@ -135,7 +139,7 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
     (review) => review.reviewer.role.level === 1,
   )
 
-  // Check if any author is not a Coordinator and needs review
+  // Check if no author is a Coordinator and coordinator review is needed
   const isNotCoordinator = article.authors.every(
     (author) => author.role.level !== 1,
   )

--- a/app/routes/administration/articles/article/_index/_loader.ts
+++ b/app/routes/administration/articles/article/_index/_loader.ts
@@ -24,7 +24,7 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
 
   const article = await prisma.article.findUnique({
     select: {
-      author: {
+      authors: {
         select: {
           id: true,
           name: true,
@@ -88,12 +88,18 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
     throw new Response('Článek nenalezen', { status: 404 })
   }
 
+  const effectiveTargetAuthorId = article.authors.some(
+    (author) => author.id === context.authorId,
+  )
+    ? context.authorId
+    : (article.authors[0]?.id ?? context.authorId)
+
   // Check view permission
   const { hasPermission: canView } = context.can({
     action: 'view',
     entity: 'article',
     state: article.state,
-    targetAuthorId: article.author.id,
+    targetAuthorId: effectiveTargetAuthorId,
   })
 
   if (!canView) {
@@ -105,7 +111,7 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
     action: 'update',
     entity: 'article',
     state: article.state,
-    targetAuthorId: article.author.id,
+    targetAuthorId: effectiveTargetAuthorId,
   })
 
   // Check delete permission
@@ -113,7 +119,7 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
     action: 'delete',
     entity: 'article',
     state: article.state,
-    targetAuthorId: article.author.id,
+    targetAuthorId: effectiveTargetAuthorId,
   })
 
   // Check publish permission (draft → published)
@@ -121,7 +127,7 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
     action: 'publish',
     entity: 'article',
     state: article.state,
-    targetAuthorId: article.author.id,
+    targetAuthorId: effectiveTargetAuthorId,
   })
 
   // Find Coordinator review (level 1)
@@ -129,8 +135,10 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
     (review) => review.reviewer.role.level === 1,
   )
 
-  // Check if author is not a Coordinator and needs review
-  const isNotCoordinator = article.author.role.level !== 1
+  // Check if any author is not a Coordinator and needs review
+  const isNotCoordinator = article.authors.every(
+    (author) => author.role.level !== 1,
+  )
   const needsCoordinatorReview = isNotCoordinator && !coordinatorReview
 
   // Check retract permission (published → draft)
@@ -138,7 +146,7 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
     action: 'retract',
     entity: 'article',
     state: article.state,
-    targetAuthorId: article.author.id,
+    targetAuthorId: effectiveTargetAuthorId,
   })
 
   // Check archive permission (published → archived)
@@ -146,7 +154,7 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
     action: 'archive',
     entity: 'article',
     state: article.state,
-    targetAuthorId: article.author.id,
+    targetAuthorId: effectiveTargetAuthorId,
   })
 
   // Check restore permission (archived → draft)
@@ -154,7 +162,7 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
     action: 'restore',
     entity: 'article',
     state: article.state,
-    targetAuthorId: article.author.id,
+    targetAuthorId: effectiveTargetAuthorId,
   })
 
   // Check review permission
@@ -162,14 +170,18 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
     action: 'review',
     entity: 'article',
     state: article.state,
-    targetAuthorId: article.author.id,
+    targetAuthorId: effectiveTargetAuthorId,
   })
 
   // Don't show review button if:
-  // 1. Author is Coordinator (level 1) - they don't need reviews
-  // 2. Current user is the author - can't review own content
-  const authorIsCoordinator = article.author.role.level === 1
-  const isOwnContent = article.author.id === context.authorId
+  // 1. All authors are Coordinators (level 1) - they don't need reviews
+  // 2. Current user is one of the authors - can't review own content
+  const authorIsCoordinator = article.authors.every(
+    (author) => author.role.level === 1,
+  )
+  const isOwnContent = article.authors.some(
+    (author) => author.id === context.authorId,
+  )
   const shouldShowReview = canReview && !authorIsCoordinator && !isOwnContent
 
   // Check if current user has already reviewed this article
@@ -179,7 +191,7 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
 
   return {
     article: {
-      author: article.author,
+      authors: article.authors,
       categories: article.categories,
       content: article.content,
       createdAt: getFormattedPublishDate(article.createdAt),

--- a/app/routes/administration/articles/article/_index/route.tsx
+++ b/app/routes/administration/articles/article/_index/route.tsx
@@ -202,7 +202,9 @@ export default function RouteComponent({
           </AdminDetailItem>
           <AdminDetailItem label="Název">{article.title}</AdminDetailItem>
           <AdminDetailItem label="Slug">{article.slug}</AdminDetailItem>
-          <AdminDetailItem label="Autor">{article.author.name}</AdminDetailItem>
+          <AdminDetailItem label="Autoři">
+            {article.authors.map((author) => author.name).join(', ')}
+          </AdminDetailItem>
           <AdminDetailItem label="Odkaz na článek">
             <Hyperlink
               href={href('/articles/:articleSlug', {

--- a/app/routes/administration/articles/article/_index/utils/publish-article.ts
+++ b/app/routes/administration/articles/article/_index/utils/publish-article.ts
@@ -16,7 +16,7 @@ export const publishArticle = (request: Request, options: Options) =>
       // Get the article with author role and reviews
       const article = await prisma.article.findUniqueOrThrow({
         select: {
-          author: {
+          authors: {
             select: {
               role: {
                 select: {
@@ -43,8 +43,10 @@ export const publishArticle = (request: Request, options: Options) =>
         where: { id: options.id },
       }) // TODO: Could be sent in form data to avoid this query?
 
-      // Check if author is not a Coordinator (level !== 1)
-      const isNotCoordinator = article.author.role.level !== 1
+      // Check if none of the authors is a Coordinator (level !== 1)
+      const isNotCoordinator = article.authors.every(
+        (author) => author.role.level !== 1,
+      )
 
       // If author is not a Coordinator, require Coordinator review
       if (isNotCoordinator) {

--- a/app/routes/administration/articles/article/edit-article/_action.ts
+++ b/app/routes/administration/articles/article/edit-article/_action.ts
@@ -32,7 +32,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     excerpt,
     categoryIds,
     tagIds,
-    authorId,
+    authorIds,
     state,
     existingImages,
     images,
@@ -41,7 +41,7 @@ export async function action({ request, params }: Route.ActionArgs) {
 
   await updateArticle(request, {
     articleId,
-    authorId,
+    authorIds,
     categoryIds,
     content,
     excerpt,

--- a/app/routes/administration/articles/article/edit-article/_loader.ts
+++ b/app/routes/administration/articles/article/edit-article/_loader.ts
@@ -18,7 +18,9 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
   // Load the article
   const article = await prisma.article.findUnique({
     select: {
-      authorId: true,
+      authors: {
+        select: { id: true },
+      },
       categories: {
         select: { id: true },
       },
@@ -54,7 +56,7 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
     entity: 'article',
     redirectTo: href('/administration/articles'),
     state: article.state,
-    targetAuthorId: article.authorId,
+    targetAuthorIds: article.authors.map((author) => author.id),
   })
 
   const [authors, categories, tags] = await Promise.all([
@@ -86,7 +88,7 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
 
   return {
     article: {
-      authorId: article.authorId,
+      authorIds: article.authors.map((author) => author.id),
       categoryIds: article.categories.map((category) => category.id),
       content: article.content,
       excerpt: article.excerpt || '',

--- a/app/routes/administration/articles/article/edit-article/_schema.ts
+++ b/app/routes/administration/articles/article/edit-article/_schema.ts
@@ -4,7 +4,7 @@ import { featuredImageSchema } from '~/config/featured-image-config'
 import { slugify } from '~/utils/slugify'
 
 export const schema = z.object({
-  authorId: z.string(),
+  authorIds: z.array(z.string()).min(1, 'Alespoň jeden autor je povinný'),
   categoryIds: z.array(z.string()).optional(),
   content: z.string({ message: 'Obsah je povinný' }),
   excerpt: z.string().optional(),

--- a/app/routes/administration/articles/article/edit-article/_schema.ts
+++ b/app/routes/administration/articles/article/edit-article/_schema.ts
@@ -4,9 +4,11 @@ import { featuredImageSchema } from '~/config/featured-image-config'
 import { slugify } from '~/utils/slugify'
 
 export const schema = z.object({
-  authorIds: z.array(z.string()).min(1, 'Alespoň jeden autor je povinný'),
+  authorIds: z
+    .array(z.string({ error: 'Vyberte autora' }))
+    .min(1, 'Alespoň jeden autor je povinný'),
   categoryIds: z.array(z.string()).optional(),
-  content: z.string({ message: 'Obsah je povinný' }),
+  content: z.string({ error: 'Obsah je povinný' }),
   excerpt: z.string().optional(),
   existingImages: z
     .array(
@@ -44,13 +46,13 @@ export const schema = z.object({
     )
     .optional(),
   slug: z
-    .string({ message: 'Slug je povinný' })
+    .string({ error: 'Slug je povinný' })
     .regex(/^\S/, 'Slug nemůže začínat mezerou')
     .regex(/^[^-]/, 'Slug nemůže začínat pomlčkou')
     .transform(slugify),
   state: z.enum(ContentState),
   tagIds: z.array(z.string()).optional(),
   title: z
-    .string({ message: 'Název je povinný' })
+    .string({ error: 'Název je povinný' })
     .regex(/^\S/, 'Název nemůže začínat mezerou'),
 })

--- a/app/routes/administration/articles/article/edit-article/_styles.module.css
+++ b/app/routes/administration/articles/article/edit-article/_styles.module.css
@@ -40,3 +40,20 @@
     height: 16px;
   }
 }
+
+.authorRow {
+  @layer route {
+    display: flex;
+    align-items: flex-end;
+    gap: 8px;
+    width: 100%;
+
+    & > section {
+      flex: 1;
+    }
+
+    & > button {
+      margin-block-end: 20px;
+    }
+  }
+}

--- a/app/routes/administration/articles/article/edit-article/route.tsx
+++ b/app/routes/administration/articles/article/edit-article/route.tsx
@@ -349,6 +349,7 @@ export default function RouteComponent({
                   errors={authorField.errors}
                   label={'Autor'}
                 >
+                  <option value={''}>— vyberte autora —</option>
                   {loaderData.authors.map((author) => (
                     <option key={author.id} value={author.id}>
                       {author.name}

--- a/app/routes/administration/articles/article/edit-article/route.tsx
+++ b/app/routes/administration/articles/article/edit-article/route.tsx
@@ -50,7 +50,7 @@ export default function RouteComponent({
   const [form, fields] = useForm({
     constraint: getZodConstraint(schema),
     defaultValue: {
-      authorId: article.authorId,
+      authorIds: article.authorIds,
       categoryIds: article.categoryIds,
       content: article.content,
       excerpt: article.excerpt,
@@ -340,19 +340,43 @@ export default function RouteComponent({
 
           <Fieldset
             disabled={isLoadingOrSubmitting}
-            legend={'Informace o autorovi'}
+            legend={'Informace o autorech'}
           >
-            <Select
-              {...getSelectProps(fields.authorId)}
-              errors={fields.authorId.errors}
-              label={'Autor'}
+            {fields.authorIds.getFieldList().map((authorField, index) => (
+              <div className={styles.authorRow} key={authorField.key}>
+                <Select
+                  {...getSelectProps(authorField)}
+                  errors={authorField.errors}
+                  label={'Autor'}
+                >
+                  {loaderData.authors.map((author) => (
+                    <option key={author.id} value={author.id}>
+                      {author.name}
+                    </option>
+                  ))}
+                </Select>
+                {index > 0 && (
+                  <AdminButton
+                    {...form.remove.getButtonProps({
+                      name: fields.authorIds.name,
+                      index,
+                    })}
+                    variant={'danger'}
+                  >
+                    <DeleteIcon className={styles.removeIcon} />
+                    Odstranit
+                  </AdminButton>
+                )}
+              </div>
+            ))}
+            <AdminButton
+              {...form.insert.getButtonProps({
+                name: fields.authorIds.name,
+                defaultValue: '',
+              })}
             >
-              {loaderData.authors.map((author) => (
-                <option key={author.id} value={author.id}>
-                  {author.name}
-                </option>
-              ))}
-            </Select>
+              Přidat autora
+            </AdminButton>
           </Fieldset>
 
           <input {...getInputProps(fields.state, { type: 'hidden' })} />

--- a/app/routes/administration/articles/article/edit-article/route.tsx
+++ b/app/routes/administration/articles/article/edit-article/route.tsx
@@ -358,8 +358,8 @@ export default function RouteComponent({
                 {index > 0 && (
                   <AdminButton
                     {...form.remove.getButtonProps({
-                      name: fields.authorIds.name,
                       index,
+                      name: fields.authorIds.name,
                     })}
                     variant={'danger'}
                   >
@@ -371,8 +371,8 @@ export default function RouteComponent({
             ))}
             <AdminButton
               {...form.insert.getButtonProps({
-                name: fields.authorIds.name,
                 defaultValue: '',
+                name: fields.authorIds.name,
               })}
             >
               Přidat autora

--- a/app/routes/administration/articles/article/edit-article/utils/update-article.server.ts
+++ b/app/routes/administration/articles/article/edit-article/utils/update-article.server.ts
@@ -9,7 +9,7 @@ import { getConvertedImageStream } from '~/utils/sharp.server'
 
 type Options = {
   articleId: string
-  authorId: string
+  authorIds: string[]
   categoryIds?: string[]
   content: string
   excerpt?: string
@@ -31,7 +31,7 @@ export async function updateArticle(
   request: Request,
   {
     articleId,
-    authorId,
+    authorIds,
     categoryIds,
     content,
     excerpt,
@@ -47,7 +47,7 @@ export async function updateArticle(
   await withAuthorPermission(request, {
     action: 'update',
     entity: 'article',
-    execute: async () => {
+    execute: async (context) => {
       // 1. Delete images that are not in existingImages
       const existingImageIds =
         existingImages?.map((existingImage) => existingImage.id) ?? []
@@ -144,7 +144,9 @@ export async function updateArticle(
       // 5. Update article
       await prisma.article.update({
         data: {
-          authorId,
+          authors: {
+            set: authorIds.map((id) => ({ id })),
+          },
           categories: {
             set: categoryIds?.map((id) => ({ id })) ?? [],
           },
@@ -175,7 +177,7 @@ export async function updateArticle(
 
       await prisma.pageSEO.upsert({
         create: {
-          authorId,
+          authorId: context.authorId,
           description: excerpt || null,
           ogImageUrl,
           pathname,
@@ -195,7 +197,7 @@ export async function updateArticle(
 
       return { id: articleId }
     },
-    target: { authorId, state },
+    target: { authorIds, state },
   })
 
   return { id: articleId }

--- a/app/routes/administration/articles/categories/add-category/utils/create-category.server.ts
+++ b/app/routes/administration/articles/categories/add-category/utils/create-category.server.ts
@@ -23,5 +23,5 @@ export const createCategory = (
         },
         select: { id: true },
       }),
-    target: { authorId, state: 'draft' },
+    target: { authorIds: [authorId], state: 'draft' },
   })

--- a/app/routes/administration/articles/categories/category/_index/_action.ts
+++ b/app/routes/administration/articles/categories/category/_index/_action.ts
@@ -33,18 +33,23 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     where: { id: categoryId },
   })
 
+  const target = {
+    authorIds: [currentCategory.authorId],
+    state: currentCategory.state,
+  }
+
   switch (intent) {
     case INTENT_VALUE.archive:
       await archiveCategory(request, {
         id: categoryId,
-        target: currentCategory,
+        target,
       })
       break
 
     case INTENT_VALUE.delete:
       await deleteCategory(request, {
         id: categoryId,
-        target: currentCategory,
+        target,
       })
 
       if (withRedirect) {
@@ -55,28 +60,28 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     case INTENT_VALUE.publish:
       await publishCategory(request, {
         id: categoryId,
-        target: currentCategory,
+        target,
       })
       break
 
     case INTENT_VALUE.restore:
       await restoreCategory(request, {
         id: categoryId,
-        target: currentCategory,
+        target,
       })
       break
 
     case INTENT_VALUE.retract:
       await retractCategory(request, {
         id: categoryId,
-        target: currentCategory,
+        target,
       })
       break
 
     case INTENT_VALUE.review:
       await reviewCategory(request, {
         id: categoryId,
-        target: currentCategory,
+        target,
       })
       break
 

--- a/app/routes/administration/articles/categories/category/edit-category/utils/update-category.server.ts
+++ b/app/routes/administration/articles/categories/category/edit-category/utils/update-category.server.ts
@@ -27,5 +27,5 @@ export const updateCategory = (
         select: { id: true },
         where: { id: categoryId },
       }),
-    target: { authorId, state },
+    target: { authorIds: [authorId], state },
   })

--- a/app/routes/administration/articles/tags/add-tag/utils/create-article-tag.server.ts
+++ b/app/routes/administration/articles/tags/add-tag/utils/create-article-tag.server.ts
@@ -23,5 +23,5 @@ export const createArticleTag = async (
         },
         select: { id: true },
       }),
-    target: { authorId, state: 'draft' },
+    target: { authorIds: [authorId], state: 'draft' },
   })

--- a/app/routes/administration/articles/tags/tag/_index/_action.ts
+++ b/app/routes/administration/articles/tags/tag/_index/_action.ts
@@ -33,18 +33,23 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     where: { id: tagId },
   }) // TODO: authorId and state could be sent in formData to reduce DB calls
 
+  const target = {
+    authorIds: [currentTag.authorId],
+    state: currentTag.state,
+  }
+
   switch (intent) {
     case INTENT_VALUE.archive:
       await archiveTag(request, {
         id: tagId,
-        target: currentTag,
+        target,
       })
       break
 
     case INTENT_VALUE.delete:
       await deleteTag(request, {
         id: tagId,
-        target: currentTag,
+        target,
       })
 
       if (withRedirect) {
@@ -55,28 +60,28 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     case INTENT_VALUE.publish:
       await publishTag(request, {
         id: tagId,
-        target: currentTag,
+        target,
       })
       break
 
     case INTENT_VALUE.restore:
       await restoreTag(request, {
         id: tagId,
-        target: currentTag,
+        target,
       })
       break
 
     case INTENT_VALUE.retract:
       await retractTag(request, {
         id: tagId,
-        target: currentTag,
+        target,
       })
       break
 
     case INTENT_VALUE.review:
       await reviewTag(request, {
         id: tagId,
-        target: currentTag,
+        target,
       })
       break
 

--- a/app/routes/administration/articles/tags/tag/edit-tag/utils/update-tag.server.ts
+++ b/app/routes/administration/articles/tags/tag/edit-tag/utils/update-tag.server.ts
@@ -27,5 +27,5 @@ export const updateTag = (
         select: { id: true },
         where: { id: tagId },
       }),
-    target: { authorId, state },
+    target: { authorIds: [authorId], state },
   })

--- a/app/routes/administration/editorial-board/members/member/_index/_action.ts
+++ b/app/routes/administration/editorial-board/members/member/_index/_action.ts
@@ -33,18 +33,23 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     where: { id: memberId },
   })
 
+  const target = {
+    authorIds: [currentMember.authorId],
+    state: currentMember.state,
+  }
+
   switch (intent) {
     case INTENT_VALUE.archive:
       await archiveMember(request, {
         id: memberId,
-        target: currentMember,
+        target,
       })
       break
 
     case INTENT_VALUE.delete:
       await deleteMember(request, {
         id: memberId,
-        target: currentMember,
+        target,
       })
 
       if (withRedirect) {
@@ -55,28 +60,28 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     case INTENT_VALUE.publish:
       await publishMember(request, {
         id: memberId,
-        target: currentMember,
+        target,
       })
       break
 
     case INTENT_VALUE.restore:
       await restoreMember(request, {
         id: memberId,
-        target: currentMember,
+        target,
       })
       break
 
     case INTENT_VALUE.retract:
       await retractMember(request, {
         id: memberId,
-        target: currentMember,
+        target,
       })
       break
 
     case INTENT_VALUE.review:
       await reviewMember(request, {
         id: memberId,
-        target: currentMember,
+        target,
       })
       break
 

--- a/app/routes/administration/editorial-board/positions/position/_index/_action.ts
+++ b/app/routes/administration/editorial-board/positions/position/_index/_action.ts
@@ -35,18 +35,23 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     },
   )
 
+  const target = {
+    authorIds: [currentPosition.authorId],
+    state: currentPosition.state,
+  }
+
   switch (intent) {
     case INTENT_VALUE.archive:
       await archivePosition(request, {
         id: positionId,
-        target: currentPosition,
+        target,
       })
       break
 
     case INTENT_VALUE.delete:
       await deletePosition(request, {
         id: positionId,
-        target: currentPosition,
+        target,
       })
 
       if (withRedirect) {
@@ -57,28 +62,28 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     case INTENT_VALUE.publish:
       await publishPosition(request, {
         id: positionId,
-        target: currentPosition,
+        target,
       })
       break
 
     case INTENT_VALUE.restore:
       await restorePosition(request, {
         id: positionId,
-        target: currentPosition,
+        target,
       })
       break
 
     case INTENT_VALUE.retract:
       await retractPosition(request, {
         id: positionId,
-        target: currentPosition,
+        target,
       })
       break
 
     case INTENT_VALUE.review:
       await reviewPosition(request, {
         id: positionId,
-        target: currentPosition,
+        target,
       })
       break
 

--- a/app/routes/administration/podcasts/podcast/_index/_action.ts
+++ b/app/routes/administration/podcasts/podcast/_index/_action.ts
@@ -33,18 +33,23 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     where: { id: podcastId },
   })
 
+  const target = {
+    authorIds: [currentPodcast.authorId],
+    state: currentPodcast.state,
+  }
+
   switch (intent) {
     case INTENT_VALUE.archive:
       await archivePodcast(request, {
         id: podcastId,
-        target: currentPodcast,
+        target,
       })
       break
 
     case INTENT_VALUE.delete:
       await deletePodcast(request, {
         id: podcastId,
-        target: currentPodcast,
+        target,
       })
 
       if (withRedirect) {
@@ -55,28 +60,28 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     case INTENT_VALUE.publish:
       await publishPodcast(request, {
         id: podcastId,
-        target: currentPodcast,
+        target,
       })
       break
 
     case INTENT_VALUE.restore:
       await restorePodcast(request, {
         id: podcastId,
-        target: currentPodcast,
+        target,
       })
       break
 
     case INTENT_VALUE.retract:
       await retractPodcast(request, {
         id: podcastId,
-        target: currentPodcast,
+        target,
       })
       break
 
     case INTENT_VALUE.review:
       await reviewPodcast(request, {
         id: podcastId,
-        target: currentPodcast,
+        target,
       })
       break
 

--- a/app/routes/administration/podcasts/podcast/episodes/episode/_index/_action.ts
+++ b/app/routes/administration/podcasts/podcast/episodes/episode/_index/_action.ts
@@ -33,18 +33,23 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     where: { id: episodeId },
   })
 
+  const target = {
+    authorIds: [currentEpisode.authorId],
+    state: currentEpisode.state,
+  }
+
   switch (intent) {
     case INTENT_VALUE.archive:
       await archiveEpisode(request, {
         id: episodeId,
-        target: currentEpisode,
+        target,
       })
       break
 
     case INTENT_VALUE.delete:
       await deleteEpisode(request, {
         id: episodeId,
-        target: currentEpisode,
+        target,
       })
 
       if (withRedirect) {
@@ -57,28 +62,28 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     case INTENT_VALUE.publish:
       await publishEpisode(request, {
         id: episodeId,
-        target: currentEpisode,
+        target,
       })
       break
 
     case INTENT_VALUE.restore:
       await restoreEpisode(request, {
         id: episodeId,
-        target: currentEpisode,
+        target,
       })
       break
 
     case INTENT_VALUE.retract:
       await retractEpisode(request, {
         id: episodeId,
-        target: currentEpisode,
+        target,
       })
       break
 
     case INTENT_VALUE.review:
       await reviewEpisode(request, {
         id: episodeId,
-        target: currentEpisode,
+        target,
       })
       break
 

--- a/app/routes/administration/podcasts/podcast/episodes/episode/links/link/_index/_action.ts
+++ b/app/routes/administration/podcasts/podcast/episodes/episode/links/link/_index/_action.ts
@@ -33,18 +33,23 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     where: { id: linkId },
   })
 
+  const target = {
+    authorIds: [currentLink.authorId],
+    state: currentLink.state,
+  }
+
   switch (intent) {
     case INTENT_VALUE.archive:
       await archiveLink(request, {
         id: linkId,
-        target: currentLink,
+        target,
       })
       break
 
     case INTENT_VALUE.delete:
       await deleteLink(request, {
         id: linkId,
-        target: currentLink,
+        target,
       })
 
       if (withRedirect) {
@@ -63,28 +68,28 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
     case INTENT_VALUE.publish:
       await publishLink(request, {
         id: linkId,
-        target: currentLink,
+        target,
       })
       break
 
     case INTENT_VALUE.restore:
       await restoreLink(request, {
         id: linkId,
-        target: currentLink,
+        target,
       })
       break
 
     case INTENT_VALUE.retract:
       await retractLink(request, {
         id: linkId,
-        target: currentLink,
+        target,
       })
       break
 
     case INTENT_VALUE.review:
       await reviewLink(request, {
         id: linkId,
-        target: currentLink,
+        target,
       })
       break
 

--- a/app/routes/website/_index/_loader.ts
+++ b/app/routes/website/_index/_loader.ts
@@ -1,12 +1,16 @@
+import { getAuthentication } from '~/utils/auth.server'
 import { prisma } from '~/utils/db.server'
+import type { Route } from './+types/route'
 
-export const loader = async () => {
+export const loader = async ({ request }: Route.LoaderArgs) => {
+  const { isAuthenticated } = await getAuthentication(request)
+
   const latestPublishedArticle = await prisma.article.findFirst({
     orderBy: {
       publishedAt: 'desc',
     },
     select: {
-      author: {
+      authors: {
         select: {
           name: true,
         },
@@ -22,7 +26,7 @@ export const loader = async () => {
       title: true,
     },
     where: {
-      state: 'published',
+      state: { in: isAuthenticated ? ['published', 'draft'] : ['published'] },
     },
   })
 

--- a/app/routes/website/_index/route.tsx
+++ b/app/routes/website/_index/route.tsx
@@ -31,7 +31,7 @@ export default function RouteComponent({ loaderData }: Route.ComponentProps) {
 
       {latestPublishedArticle && (
         <ArticleHero
-          authors={[{ name: latestPublishedArticle.author.name }]}
+          authors={latestPublishedArticle.authors}
           imageAlt={latestPublishedArticle.featuredImage?.altText}
           imageSrc={latestArticleImageSrc}
           publishDate={latestPublishedArticle.publishedAt}

--- a/app/routes/website/articles/_index/_loader.ts
+++ b/app/routes/website/articles/_index/_loader.ts
@@ -20,7 +20,7 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
         publishedAt: 'desc',
       },
       select: {
-        author: {
+        authors: {
           select: {
             name: true,
           },

--- a/app/routes/website/articles/_index/route.tsx
+++ b/app/routes/website/articles/_index/route.tsx
@@ -50,7 +50,9 @@ export default function RouteComponent({ loaderData }: Route.ComponentProps) {
                 />
                 <ContentLinkTitle>{article.title}</ContentLinkTitle>
                 <ContentLinkFooter>
-                  <ContentLinkAuthor>{article.author.name}</ContentLinkAuthor>
+                  <ContentLinkAuthor>
+                    {article.authors.map((author) => author.name).join(', ')}
+                  </ContentLinkAuthor>
                   <ContentLinkPublishDate date={article.publishedAt} />
                 </ContentLinkFooter>
               </ContentLink>

--- a/app/routes/website/articles/article/_loader.ts
+++ b/app/routes/website/articles/article/_loader.ts
@@ -9,7 +9,7 @@ export const loader = async ({ params, request }: Route.LoaderArgs) => {
 
   const article = await prisma.article.findUnique({
     select: {
-      author: {
+      authors: {
         select: {
           name: true,
         },

--- a/app/routes/website/articles/article/route.tsx
+++ b/app/routes/website/articles/article/route.tsx
@@ -24,7 +24,8 @@ export default function ArticleRoute({ loaderData }: Route.ComponentProps) {
       <HeadlineGroup>
         <Headline>{article.title}</Headline>
         <Subheadline>
-          {article.author.name} · {getFormattedPublishDate(article.publishedAt)}
+          {article.authors.map((author) => author.name).join(', ')} ·{' '}
+          {getFormattedPublishDate(article.publishedAt)}
         </Subheadline>
       </HeadlineGroup>
 

--- a/app/utils/permissions/author/actions/with-author-permission.server.ts
+++ b/app/utils/permissions/author/actions/with-author-permission.server.ts
@@ -15,7 +15,7 @@ import {
 type Options<T> = {
   entity: AuthorPermissionEntity
   action: AuthorPermissionAction
-  target: { authorId: string; state: ContentState }
+  target: { authorIds: string[]; state: ContentState }
   execute: (context: AuthorPermissionContext) => Promise<T>
   errorMessage?: string
 }
@@ -31,11 +31,17 @@ export async function withAuthorPermission<T>(
     entities: [options.entity],
   })
 
+  const effectiveTargetAuthorId = options.target.authorIds.includes(
+    context.authorId,
+  )
+    ? context.authorId
+    : (options.target.authorIds[0] ?? context.authorId)
+
   const { hasPermission } = context.can({
     action: options.action,
     entity: options.entity,
     state: options.target.state,
-    targetAuthorId: options.target.authorId,
+    targetAuthorId: effectiveTargetAuthorId,
   })
 
   invariantResponse(

--- a/app/utils/permissions/author/actions/with-author-permission.server.ts
+++ b/app/utils/permissions/author/actions/with-author-permission.server.ts
@@ -31,11 +31,16 @@ export async function withAuthorPermission<T>(
     entities: [options.entity],
   })
 
+  invariantResponse(
+    options.target.authorIds.length > 0,
+    `Cannot determine permission target: ${options.entity} has no authors.`,
+  )
+
   const effectiveTargetAuthorId = options.target.authorIds.includes(
     context.authorId,
   )
     ? context.authorId
-    : (options.target.authorIds[0] ?? context.authorId)
+    : options.target.authorIds[0]
 
   const { hasPermission } = context.can({
     action: options.action,

--- a/app/utils/permissions/author/guards/require-author-permission.server.ts
+++ b/app/utils/permissions/author/guards/require-author-permission.server.ts
@@ -22,9 +22,12 @@ export function requireAuthorPermission(
 ) {
   let effectiveTargetAuthorId = options.targetAuthorId
   if (options.targetAuthorIds !== undefined) {
+    if (options.targetAuthorIds.length === 0) {
+      throw redirect(options.redirectTo ?? '/administration')
+    }
     effectiveTargetAuthorId = options.targetAuthorIds.includes(context.authorId)
       ? context.authorId
-      : (options.targetAuthorIds[0] ?? context.authorId)
+      : options.targetAuthorIds[0]
   }
 
   const { hasPermission, hasOwn, hasAny } = context.can({

--- a/app/utils/permissions/author/guards/require-author-permission.server.ts
+++ b/app/utils/permissions/author/guards/require-author-permission.server.ts
@@ -12,6 +12,7 @@ type RequireAuthorPermissionOptions = {
   action: AuthorPermissionAction
   state?: ContentState
   targetAuthorId?: string
+  targetAuthorIds?: string[]
   redirectTo?: string
 }
 
@@ -19,11 +20,18 @@ export function requireAuthorPermission(
   context: AuthorPermissionContext,
   options: RequireAuthorPermissionOptions,
 ) {
+  let effectiveTargetAuthorId = options.targetAuthorId
+  if (options.targetAuthorIds !== undefined) {
+    effectiveTargetAuthorId = options.targetAuthorIds.includes(context.authorId)
+      ? context.authorId
+      : (options.targetAuthorIds[0] ?? context.authorId)
+  }
+
   const { hasPermission, hasOwn, hasAny } = context.can({
     action: options.action,
     entity: options.entity,
     state: options.state,
-    targetAuthorId: options.targetAuthorId,
+    targetAuthorId: effectiveTargetAuthorId,
   })
 
   if (!hasPermission) {

--- a/prisma/migrations/20260410191310_add_article_authors_many_to_many/migration.sql
+++ b/prisma/migrations/20260410191310_add_article_authors_many_to_many/migration.sql
@@ -1,0 +1,45 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `authorId` on the `Article` table. All the data in the column will be lost.
+
+*/
+-- CreateTable
+CREATE TABLE "_ArticleAuthors" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+    CONSTRAINT "_ArticleAuthors_A_fkey" FOREIGN KEY ("A") REFERENCES "Article" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "_ArticleAuthors_B_fkey" FOREIGN KEY ("B") REFERENCES "Author" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Article" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "slug" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "excerpt" TEXT,
+    "content" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    "publishedAt" DATETIME,
+    "state" TEXT NOT NULL DEFAULT 'draft',
+    "featuredImageId" TEXT,
+    CONSTRAINT "Article_featuredImageId_fkey" FOREIGN KEY ("featuredImageId") REFERENCES "ArticleImage" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Article" ("content", "createdAt", "excerpt", "featuredImageId", "id", "publishedAt", "slug", "state", "title", "updatedAt") SELECT "content", "createdAt", "excerpt", "featuredImageId", "id", "publishedAt", "slug", "state", "title", "updatedAt" FROM "Article";
+-- Migrate existing author relations to the join table
+INSERT INTO "_ArticleAuthors" ("A", "B") SELECT "id", "authorId" FROM "Article";
+DROP TABLE "Article";
+ALTER TABLE "new_Article" RENAME TO "Article";
+CREATE UNIQUE INDEX "Article_slug_key" ON "Article"("slug");
+CREATE UNIQUE INDEX "Article_featuredImageId_key" ON "Article"("featuredImageId");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_ArticleAuthors_AB_unique" ON "_ArticleAuthors"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_ArticleAuthors_B_index" ON "_ArticleAuthors"("B");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -167,7 +167,7 @@ model Author {
   role                    AuthorRole               @relation(fields: [roleId], references: [id], onDelete: Restrict, onUpdate: Cascade)
   roleId                  String
   // Created content
-  articles                Article[]                @relation("ArticleCreator")
+  articles                Article[]                @relation("ArticleAuthors")
   articleTags             ArticleTag[]             @relation("ArticleTagCreator")
   articleCategories       ArticleCategory[]        @relation("ArticleCategoryCreator")
   editorialBoardMembers   EditorialBoardMember[]   @relation("EditorialBoardMemberCreator")
@@ -411,17 +411,13 @@ model Article {
   updatedAt       DateTime          @updatedAt
   publishedAt     DateTime?
   state           ContentState      @default(draft)
-  author          Author            @relation("ArticleCreator", fields: [authorId], references: [id], onDelete: Restrict, onUpdate: Cascade)
-  authorId        String
+  authors         Author[]          @relation("ArticleAuthors")
   images          ArticleImage[]    @relation("ArticleImages")
   featuredImageId String?           @unique
   featuredImage   ArticleImage?     @relation("ArticleFeaturedImage", fields: [featuredImageId], references: [id], onDelete: SetNull, onUpdate: Cascade)
   tags            ArticleTag[]
   categories      ArticleCategory[]
   reviews         Review[]          @relation("ArticleReviews")
-
-  // non-unique foreign key
-  @@index([authorId])
 }
 
 model ArticleImage {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -166,8 +166,9 @@ model Author {
   user                    User?
   role                    AuthorRole               @relation(fields: [roleId], references: [id], onDelete: Restrict, onUpdate: Cascade)
   roleId                  String
-  // Created content
+  // Authored content
   articles                Article[]                @relation("ArticleAuthors")
+  // Created content
   articleTags             ArticleTag[]             @relation("ArticleTagCreator")
   articleCategories       ArticleCategory[]        @relation("ArticleCategoryCreator")
   editorialBoardMembers   EditorialBoardMember[]   @relation("EditorialBoardMemberCreator")


### PR DESCRIPTION
## Summary

- Přidána implicitní M:N relace mezi `Article` a `Author` (Prisma tabulka `_ArticleAuthors`) pro podporu více autorů na jednom článku
- Aktualizovány všechny komponenty pro správu článků (přidání, úprava, zobrazení) pro práci s více autory
- Opravena logika oprávnění autorů — kontrola nyní správně prochází přes pole autorů
- Refaktorovány CSS proměnné pro konzistentní design

## Test plan

- [x] Ověřit, že lze přidat článek s více autory
- [x] Ověřit, že lze upravit autory existujícího článku
- [x] Ověřit, že se oprávnění (draft/publish/retract/archive) správně aplikují přes pole autorů
- [x] Ověřit, že se články správně zobrazují na veřejném webu s více autory
- [x] Ověřit, že migrace databáze proběhne bez chyb