### PR TITLE
fix: delete stored image variants when a parent entity is deleted (#90)

### DIFF
--- a/app/routes/administration/archive/issue/_index/utils/delete-issue.ts
+++ b/app/routes/administration/archive/issue/_index/utils/delete-issue.ts
@@ -1,4 +1,5 @@
 import { prisma } from '~/utils/db.server'
+import { deleteRowWithImages } from '~/utils/image-store/store-image.server'
 import { withAuthorPermission } from '~/utils/permissions/author/actions/with-author-permission.server'
 
 type Options = {
@@ -10,6 +11,16 @@ export const deleteIssue = (request: Request, options: Options) =>
   withAuthorPermission(request, {
     action: 'delete',
     entity: 'issue',
-    execute: () => prisma.issue.delete({ where: { id: options.id } }),
+    execute: () =>
+      deleteRowWithImages(
+        async () => {
+          const issue = await prisma.issue.findUnique({
+            select: { cover: { select: { id: true } } },
+            where: { id: options.id },
+          })
+          return issue?.cover ? [issue.cover.id] : []
+        },
+        () => prisma.issue.delete({ where: { id: options.id } }),
+      ),
     target: options.target,
   })

--- a/app/routes/administration/articles/article/_index/utils/delete-article.ts
+++ b/app/routes/administration/articles/article/_index/utils/delete-article.ts
@@ -1,4 +1,5 @@
 import { prisma } from '~/utils/db.server'
+import { deleteRowWithImages } from '~/utils/image-store/store-image.server'
 import { withAuthorPermission } from '~/utils/permissions/author/actions/with-author-permission.server'
 
 type Options = {
@@ -11,8 +12,15 @@ export const deleteArticle = (request: Request, options: Options) =>
     action: 'delete',
     entity: 'article',
     execute: () =>
-      prisma.article.delete({
-        where: { id: options.id },
-      }),
+      deleteRowWithImages(
+        async () => {
+          const images = await prisma.articleImage.findMany({
+            select: { id: true },
+            where: { articleId: options.id },
+          })
+          return images.map((image) => image.id)
+        },
+        () => prisma.article.delete({ where: { id: options.id } }),
+      ),
     target: options.target,
   })

--- a/app/routes/administration/podcasts/podcast/_index/utils/delete-podcast.ts
+++ b/app/routes/administration/podcasts/podcast/_index/utils/delete-podcast.ts
@@ -1,4 +1,5 @@
 import { prisma } from '~/utils/db.server'
+import { deleteRowWithImages } from '~/utils/image-store/store-image.server'
 import { withAuthorPermission } from '~/utils/permissions/author/actions/with-author-permission.server'
 
 type Options = {
@@ -10,6 +11,16 @@ export const deletePodcast = (request: Request, options: Options) =>
   withAuthorPermission(request, {
     action: 'delete',
     entity: 'podcast',
-    execute: () => prisma.podcast.delete({ where: { id: options.id } }),
+    execute: () =>
+      deleteRowWithImages(
+        async () => {
+          const podcast = await prisma.podcast.findUnique({
+            select: { cover: { select: { id: true } } },
+            where: { id: options.id },
+          })
+          return podcast?.cover ? [podcast.cover.id] : []
+        },
+        () => prisma.podcast.delete({ where: { id: options.id } }),
+      ),
     target: options.target,
   })

--- a/app/routes/administration/podcasts/podcast/episodes/episode/_index/utils/delete-episode.ts
+++ b/app/routes/administration/podcasts/podcast/episodes/episode/_index/utils/delete-episode.ts
@@ -1,4 +1,5 @@
 import { prisma } from '~/utils/db.server'
+import { deleteRowWithImages } from '~/utils/image-store/store-image.server'
 import { withAuthorPermission } from '~/utils/permissions/author/actions/with-author-permission.server'
 
 type Options = {
@@ -10,6 +11,16 @@ export const deleteEpisode = (request: Request, options: Options) =>
   withAuthorPermission(request, {
     action: 'delete',
     entity: 'podcast_episode',
-    execute: () => prisma.podcastEpisode.delete({ where: { id: options.id } }),
+    execute: () =>
+      deleteRowWithImages(
+        async () => {
+          const episode = await prisma.podcastEpisode.findUnique({
+            select: { cover: { select: { id: true } } },
+            where: { id: options.id },
+          })
+          return episode?.cover ? [episode.cover.id] : []
+        },
+        () => prisma.podcastEpisode.delete({ where: { id: options.id } }),
+      ),
     target: options.target,
   })

--- a/app/utils/image-store/store-image.server.test.ts
+++ b/app/utils/image-store/store-image.server.test.ts
@@ -38,25 +38,22 @@ describe('deleteRowWithImages', () => {
     const result = await deleteRowWithImages(loadImageIds, deleteRow)
 
     // The DB delete commits before any file is removed (delete files after DB).
-    expect(order).toEqual([
-      'load',
-      'delete-row',
-      'delete-files',
-      'delete-files',
-    ])
+    expect(order).toEqual(['load', 'delete-row', 'delete-files'])
     // The helper is transparent to the delete's return value.
     expect(result).toBe('result')
   })
 
-  test('removes the store prefix for each image id', async () => {
+  test('removes every image prefix in a single batched store call', async () => {
     await deleteRowWithImages(
       async () => ['ab123', 'cd456'],
       async () => undefined,
     )
 
-    expect(storeDelete).toHaveBeenCalledTimes(2)
-    expect(storeDelete).toHaveBeenCalledWith([buildImagePrefix('ab123')])
-    expect(storeDelete).toHaveBeenCalledWith([buildImagePrefix('cd456')])
+    expect(storeDelete).toHaveBeenCalledTimes(1)
+    expect(storeDelete).toHaveBeenCalledWith([
+      buildImagePrefix('ab123'),
+      buildImagePrefix('cd456'),
+    ])
   })
 
   test('is a no-op when there are no image ids', async () => {

--- a/app/utils/image-store/store-image.server.test.ts
+++ b/app/utils/image-store/store-image.server.test.ts
@@ -4,8 +4,8 @@ import { buildImagePrefix } from './image-key'
 import { deleteRowWithImages } from './store-image.server'
 
 // Replace the real store with a spy so the store files are never touched; the
-// helper (and the `deleteImage` it calls) run for real, so the test also covers
-// that the right store prefixes are removed.
+// helper runs for real, so the test also covers that it removes the right store
+// prefixes via `imageStore.delete`.
 const storeDelete = vi.fn(async (_prefixes: string[]) => {})
 
 vi.mock('./image-store.server', () => ({

--- a/app/utils/image-store/store-image.server.test.ts
+++ b/app/utils/image-store/store-image.server.test.ts
@@ -37,7 +37,7 @@ describe('deleteRowWithImages', () => {
 
     const result = await deleteRowWithImages(loadImageIds, deleteRow)
 
-    // The DB delete commits before any file is removed (delete files after DB).
+    // `deleteRow` resolves before any file is removed (delete files after DB).
     expect(order).toEqual(['load', 'delete-row', 'delete-files'])
     // The helper is transparent to the delete's return value.
     expect(result).toBe('result')

--- a/app/utils/image-store/store-image.server.test.ts
+++ b/app/utils/image-store/store-image.server.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { buildImagePrefix } from './image-key'
+import { deleteRowWithImages } from './store-image.server'
+
+// Replace the real store with a spy so the store files are never touched; the
+// helper (and the `deleteImage` it calls) run for real, so the test also covers
+// that the right store prefixes are removed.
+const storeDelete = vi.fn(async (_prefixes: string[]) => {})
+
+vi.mock('./image-store.server', () => ({
+  imageStore: {
+    delete: (prefixes: string[]) => storeDelete(prefixes),
+  },
+}))
+
+beforeEach(() => {
+  storeDelete.mockReset()
+  storeDelete.mockImplementation(async () => {})
+})
+
+describe('deleteRowWithImages', () => {
+  test('loads ids and deletes the row before removing any store files', async () => {
+    const order: string[] = []
+
+    const loadImageIds = vi.fn(async () => {
+      order.push('load')
+      return ['ab123', 'cd456']
+    })
+    const deleteRow = vi.fn(async () => {
+      order.push('delete-row')
+      return 'result'
+    })
+    storeDelete.mockImplementation(async () => {
+      order.push('delete-files')
+    })
+
+    const result = await deleteRowWithImages(loadImageIds, deleteRow)
+
+    // The DB delete commits before any file is removed (delete files after DB).
+    expect(order).toEqual([
+      'load',
+      'delete-row',
+      'delete-files',
+      'delete-files',
+    ])
+    // The helper is transparent to the delete's return value.
+    expect(result).toBe('result')
+  })
+
+  test('removes the store prefix for each image id', async () => {
+    await deleteRowWithImages(
+      async () => ['ab123', 'cd456'],
+      async () => undefined,
+    )
+
+    expect(storeDelete).toHaveBeenCalledTimes(2)
+    expect(storeDelete).toHaveBeenCalledWith([buildImagePrefix('ab123')])
+    expect(storeDelete).toHaveBeenCalledWith([buildImagePrefix('cd456')])
+  })
+
+  test('is a no-op when there are no image ids', async () => {
+    const result = await deleteRowWithImages(
+      async () => [],
+      async () => 'ok',
+    )
+
+    expect(result).toBe('ok')
+    expect(storeDelete).not.toHaveBeenCalled()
+  })
+
+  test('keeps store files when the row delete fails', async () => {
+    await expect(
+      deleteRowWithImages(
+        async () => ['ab123'],
+        async () => {
+          throw new Error('delete failed')
+        },
+      ),
+    ).rejects.toThrow('delete failed')
+
+    expect(storeDelete).not.toHaveBeenCalled()
+  })
+})

--- a/app/utils/image-store/store-image.server.ts
+++ b/app/utils/image-store/store-image.server.ts
@@ -107,6 +107,21 @@ export async function deleteImage(id: string) {
   await imageStore.delete([buildImagePrefix(id)])
 }
 
+// Delete a row (or rows) and then remove the associated image-store files.
+// Ordering rule (delete files after DB, never before): the store ids are loaded
+// and the DB delete runs first; the store files are wiped only AFTER the delete
+// has committed, so a failed delete never removes files that still have live
+// rows. A no-op when there are no image ids (e.g. the parent has no cover).
+export async function deleteRowWithImages<T>(
+  loadImageIds: () => Promise<string[]>,
+  deleteRow: () => Promise<T>,
+): Promise<T> {
+  const imageIds = await loadImageIds()
+  const result = await deleteRow()
+  await Promise.all(imageIds.map((id) => deleteImage(id)))
+  return result
+}
+
 // Row data for a single cover column, spread into a Prisma `cover.update.data`.
 // The store fields are absent when the cover file is left unchanged (only the
 // alt text is written).

--- a/app/utils/image-store/store-image.server.ts
+++ b/app/utils/image-store/store-image.server.ts
@@ -109,11 +109,13 @@ export async function deleteImage(id: string) {
 
 // Delete a row (or rows) and then remove the associated image-store files.
 // Ordering rule (delete files after DB, never before): the store ids are loaded
-// and the DB delete runs first; the store files are wiped only AFTER the delete
-// has committed, so a failed delete never removes files that still have live
-// rows. Every id's prefix goes in a single `delete` call so the backend can
-// batch/limit the removals itself. A no-op when there are no image ids (e.g. the
-// parent has no cover).
+// and the DB delete runs first; the store files are wiped only AFTER `deleteRow`
+// resolves, so a rejected delete never removes files that still have live rows.
+// `deleteRow` must therefore be a delete that is already durable once it
+// resolves (a standalone `prisma.*.delete`, not an operation queued inside an
+// interactive `$transaction` callback that commits later). Every id's prefix
+// goes in a single `delete` call so the backend can batch/limit the removals
+// itself. A no-op when there are no image ids (e.g. the parent has no cover).
 export async function deleteRowWithImages<T>(
   loadImageIds: () => Promise<string[]>,
   deleteRow: () => Promise<T>,

--- a/app/utils/image-store/store-image.server.ts
+++ b/app/utils/image-store/store-image.server.ts
@@ -111,14 +111,18 @@ export async function deleteImage(id: string) {
 // Ordering rule (delete files after DB, never before): the store ids are loaded
 // and the DB delete runs first; the store files are wiped only AFTER the delete
 // has committed, so a failed delete never removes files that still have live
-// rows. A no-op when there are no image ids (e.g. the parent has no cover).
+// rows. Every id's prefix goes in a single `delete` call so the backend can
+// batch/limit the removals itself. A no-op when there are no image ids (e.g. the
+// parent has no cover).
 export async function deleteRowWithImages<T>(
   loadImageIds: () => Promise<string[]>,
   deleteRow: () => Promise<T>,
 ): Promise<T> {
   const imageIds = await loadImageIds()
   const result = await deleteRow()
-  await Promise.all(imageIds.map((id) => deleteImage(id)))
+  if (imageIds.length > 0) {
+    await imageStore.delete(imageIds.map((id) => buildImagePrefix(id)))
+  }
   return result
 }
 


### PR DESCRIPTION
Closes #90.

## Problem

Deleting an article/podcast/episode/issue removed its cover/image DB rows via `onDelete: Cascade`, but **left the variant files orphaned in the image store** (Tigris bucket or the volume). A DB cascade only touches DB rows; the variant files live outside the DB, so nothing removed them. Pre-existing bug, independent of the volume→Tigris migration.

## Fix

- Added a shared `deleteRowWithImages(loadImageIds, deleteRow)` helper in `store-image.server.ts`: loads the store ids, runs the DB delete, then removes files via the existing `deleteImage` — enforcing the *delete files after DB, never before* ordering rule (a failed delete never removes files).
- Wired all four delete utils to use it:
  - **Article** collects **all** `ArticleImage` ids (an article has multiple images, not a single cover).
  - **Podcast / episode / issue** load the single `cover.id` via the parent relation (0 or 1).
- The store key is the image/cover **row id** (what `storeImageVariants` is called with), so those ids are passed, not the parent id.

## Verification

- `pnpm app:typecheck` + `pnpm test` green.
- New unit tests in `store-image.server.test.ts` cover: ordering (DB commit before any file removal), per-id prefix cleanup, no-op when the parent has no cover, and keep-files-on-failed-delete.
- Backend-agnostic: both `tigris` and `volume` go through the same `ImageStore.delete` prefix contract. Live-store end-to-end deletion has not been run manually.