### PR TITLE
fix: env.js caching — let the ETag drive revalidation instead of immutable (#87)

### DIFF
--- a/app/routes/resources/env-script/_loader.ts
+++ b/app/routes/resources/env-script/_loader.ts
@@ -1,14 +1,23 @@
 import { getContentHash } from '~/utils/hash.server'
 
-export async function loader() {
-  const script = `window.ENV = ${JSON.stringify(ENV)};`
-  const version = getContentHash(script)
+import type { Route } from './+types/route'
 
-  return new Response(script, {
-    headers: {
-      'Cache-Control': 'public, immutable, max-age=31536000',
-      'Content-Type': 'application/javascript',
-      ETag: `"${version}"`,
-    },
-  })
+export const loader = async ({ request }: Route.LoaderArgs) => {
+  const script = `window.ENV = ${JSON.stringify(ENV)};`
+  const etag = `"${getContentHash(script)}"`
+
+  const headers = {
+    // Stable URL: `immutable`/long max-age would let a changed window.ENV go stale.
+    // `no-cache` = may be stored, but must revalidate via ETag before use.
+    'Cache-Control': 'public, no-cache',
+    'Content-Type': 'application/javascript',
+    ETag: etag,
+  }
+
+  // Cheap 304 when the client's cached copy still matches.
+  if (request.headers.get('If-None-Match') === etag) {
+    return new Response(null, { headers, status: 304 })
+  }
+
+  return new Response(script, { headers })
 }


### PR DESCRIPTION
Closes #87

## Problem

`/resources/env.js` (which injects `window.ENV` on every page) was served with
`Cache-Control: public, immutable, max-age=31536000` on a **stable URL** — the
version/hash is not in the path. `immutable` tells the browser and Cloudflare not to
revalidate while fresh, so the content-hash `ETag` never got a chance to bust the cache.
If `window.ENV` ever changed (e.g. `BASE_URL`, `MODE`, a new client-exposed var), clients
and the CF edge could serve the stale value for up to a year.

## Fix

In `app/routes/resources/env-script/_loader.ts`:

- `Cache-Control` → `public, no-cache` (may be stored, but must revalidate via the `ETag`
  before use). The hashed-URL approach was explicitly rejected in the issue.
- Handle `If-None-Match` so a matching client gets a cheap `304 Not Modified` instead of
  the full body on every load.
- Loader signature aligned with sibling resource loaders (`{ request }: Route.LoaderArgs`).

`checkCacheValidation` from `cache.server.ts` was intentionally **not** reused — it
hardcodes `immutable` into its 304 response and requires a `Last-Modified` timestamp, both
wrong for env.js (would re-introduce the exact bug on the 304 path).

No change to the Cloudflare image Cache Rule (targets `.avif`/`.jpeg`, not `env.js`).

## Verification

- `pnpm app:typecheck`, biome check, and the full test suite (78 tests) pass.
- Local runtime (`curl`):
  - `GET /resources/env.js` → `cache-control: public, no-cache`, an `ETag`, no `immutable`/`max-age`.
  - Conditional request with matching `If-None-Match` → `304 Not Modified`, empty body.
  - Non-matching / absent `If-None-Match` → `200` with the full `window.ENV = {...}` body.