### PR TITLE
chore(deps-dev): bump vite from 8.1.2 to 8.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "storybook": "10.3.5",
     "tsx": "4.22.4",
     "typescript": "6.0.2",
-    "vite": "8.1.2",
+    "vite": "8.1.3",
     "vitest": "4.1.4"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,22 +101,22 @@ importers:
         version: 2.4.10
       '@react-router/dev':
         specifier: 7.14.0
-        version: 7.14.0(@react-router/serve@7.14.0(react-router@7.15.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.2))(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.15.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@6.0.2)(vite@8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))
+        version: 7.14.0(@react-router/serve@7.14.0(react-router@7.15.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.2))(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.15.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@6.0.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))
       '@storybook/addon-a11y':
         specifier: 10.3.5
         version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       '@storybook/addon-docs':
         specifier: 10.3.5
-        version: 10.3.5(@types/react@19.2.14)(esbuild@0.28.1)(rollup@4.53.3)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))
+        version: 10.3.5(@types/react@19.2.14)(esbuild@0.28.1)(rollup@4.53.3)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))
       '@storybook/addon-onboarding':
         specifier: 10.3.5
         version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       '@storybook/addon-vitest':
         specifier: 10.3.5
-        version: 10.3.5(@vitest/runner@4.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@4.1.4(@types/node@25.5.2)(vite@8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)))
+        version: 10.3.5(@vitest/runner@4.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@4.1.4(@types/node@25.5.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)))
       '@storybook/react-vite':
         specifier: 10.3.5
-        version: 10.3.5(esbuild@0.28.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.53.3)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.2)(vite@8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))
+        version: 10.3.5(esbuild@0.28.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.53.3)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))
       '@types/node':
         specifier: 25.5.2
         version: 25.5.2
@@ -128,7 +128,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: 6.0.1
-        version: 6.0.1(vite@8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))
+        version: 6.0.1(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))
       autoprefixer:
         specifier: 10.4.27
         version: 10.4.27(postcss@8.5.10)
@@ -154,11 +154,11 @@ importers:
         specifier: 6.0.2
         version: 6.0.2
       vite:
-        specifier: 8.1.2
-        version: 8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)
+        specifier: 8.1.3
+        version: 8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)
       vitest:
         specifier: 4.1.4
-        version: 4.1.4(@types/node@25.5.2)(vite@8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))
+        version: 4.1.4(@types/node@25.5.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))
 
 packages:
 
@@ -3775,8 +3775,8 @@ packages:
       yaml:
         optional: true
 
-  vite@8.1.2:
-    resolution: {integrity: sha512-6YYPbRXTxx6bRXmOn7XdnQAy5DQNHhDgtjhDHI13oe4pY93kkcdGJWxpGwOm++/Wh0QpQhDrpIoVMrmrsI5AGQ==}
+  vite@8.1.3:
+    resolution: {integrity: sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -4641,11 +4641,11 @@ snapshots:
   '@img/sharp-win32-x64@0.35.3':
     optional: true
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.2)(vite@8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@6.0.2)
-      vite: 8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)
+      vite: 8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)
     optionalDependencies:
       typescript: 6.0.2
 
@@ -4954,7 +4954,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@react-router/dev@7.14.0(@react-router/serve@7.14.0(react-router@7.15.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.2))(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.15.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@6.0.2)(vite@8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))':
+  '@react-router/dev@7.14.0(@react-router/serve@7.14.0(react-router@7.15.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.2))(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(react-router@7.15.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(tsx@4.22.4)(typescript@6.0.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/generator': 7.28.5
@@ -4984,7 +4984,7 @@ snapshots:
       semver: 7.7.3
       tinyglobby: 0.2.15
       valibot: 1.2.0(typescript@6.0.2)
-      vite: 8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)
+      vite: 8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)
       vite-node: 3.2.4(@types/node@25.5.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)
     optionalDependencies:
       '@react-router/serve': 7.14.0(react-router@7.15.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.2)
@@ -5219,10 +5219,10 @@ snapshots:
       axe-core: 4.11.0
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
-  '@storybook/addon-docs@10.3.5(@types/react@19.2.14)(esbuild@0.28.1)(rollup@4.53.3)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))':
+  '@storybook/addon-docs@10.3.5(@types/react@19.2.14)(esbuild@0.28.1)(rollup@4.53.3)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.28.1)(rollup@4.53.3)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.28.1)(rollup@4.53.3)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))
       '@storybook/icons': 2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@storybook/react-dom-shim': 10.3.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
       react: 19.2.5
@@ -5240,37 +5240,37 @@ snapshots:
     dependencies:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
-  '@storybook/addon-vitest@10.3.5(@vitest/runner@4.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@4.1.4(@types/node@25.5.2)(vite@8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)))':
+  '@storybook/addon-vitest@10.3.5(@vitest/runner@4.1.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vitest@4.1.4(@types/node@25.5.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)))':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     optionalDependencies:
       '@vitest/runner': 4.1.4
-      vitest: 4.1.4(@types/node@25.5.2)(vite@8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))
+      vitest: 4.1.4(@types/node@25.5.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.3.5(esbuild@0.28.1)(rollup@4.53.3)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))':
+  '@storybook/builder-vite@10.3.5(esbuild@0.28.1)(rollup@4.53.3)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))':
     dependencies:
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.28.1)(rollup@4.53.3)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.28.1)(rollup@4.53.3)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       ts-dedent: 2.2.0
-      vite: 8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)
+      vite: 8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.3.5(esbuild@0.28.1)(rollup@4.53.3)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))':
+  '@storybook/csf-plugin@10.3.5(esbuild@0.28.1)(rollup@4.53.3)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))':
     dependencies:
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.1
       rollup: 4.53.3
-      vite: 8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)
+      vite: 8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)
 
   '@storybook/global@5.0.0': {}
 
@@ -5285,11 +5285,11 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
 
-  '@storybook/react-vite@10.3.5(esbuild@0.28.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.53.3)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.2)(vite@8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))':
+  '@storybook/react-vite@10.3.5(esbuild@0.28.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.53.3)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.2)(vite@8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))
       '@rollup/pluginutils': 5.3.0(rollup@4.53.3)
-      '@storybook/builder-vite': 10.3.5(esbuild@0.28.1)(rollup@4.53.3)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))
+      '@storybook/builder-vite': 10.3.5(esbuild@0.28.1)(rollup@4.53.3)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))
       '@storybook/react': 10.3.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.2)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -5299,7 +5299,7 @@ snapshots:
       resolve: 1.22.11
       storybook: 10.3.5(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tsconfig-paths: 4.2.0
-      vite: 8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)
+      vite: 8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -5595,10 +5595,10 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
-  '@vitejs/plugin-react@6.0.1(vite@8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))':
+  '@vitejs/plugin-react@6.0.1(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)
+      vite: 8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -5617,13 +5617,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))':
+  '@vitest/mocker@4.1.4(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)
+      vite: 8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -7542,7 +7542,7 @@ snapshots:
       lightningcss: 1.32.0
       tsx: 4.22.4
 
-  vite@8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4):
+  vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
@@ -7556,10 +7556,10 @@ snapshots:
       jiti: 2.6.1
       tsx: 4.22.4
 
-  vitest@4.1.4(@types/node@25.5.2)(vite@8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)):
+  vitest@4.1.4(@types/node@25.5.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))
+      '@vitest/mocker': 4.1.4(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -7576,7 +7576,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.1.2(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)
+      vite: 8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.6.1)(tsx@4.22.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.5.2


### PR DESCRIPTION
Bumps the direct `vite` devDependency from 8.1.2 to 8.1.3 to resolve the Dependabot security alerts (`server.fs.deny` bypass on Windows; launch-editor NTLMv2 hash disclosure).

Dependabot's original PR for this (#76) was auto-superseded by #94 when the react-router merge changed the lockfile, but the recreated #94 only covered the *transitive* vite (7.3.1 → 7.3.6). This PR lands the remaining direct bump. Verified with typecheck, tests (78 passing), and a production build.

Part of #93.