### PR TITLE
chore(deps): bump @conform-to/react and @conform-to/zod to 1.19.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
     "@aws-sdk/client-s3": "3.1079.0",
-    "@conform-to/react": "1.18.0",
-    "@conform-to/zod": "1.18.0",
+    "@conform-to/react": "1.19.4",
+    "@conform-to/zod": "1.19.4",
     "@epic-web/invariant": "1.0.0",
     "@epic-web/remember": "1.1.0",
     "@mjackson/form-data-parser": "0.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,11 +12,11 @@ importers:
         specifier: 3.1079.0
         version: 3.1079.0
       '@conform-to/react':
-        specifier: 1.18.0
-        version: 1.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 1.19.4
+        version: 1.19.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@conform-to/zod':
-        specifier: 1.18.0
-        version: 1.18.0(zod@4.3.6)
+        specifier: 1.19.4
+        version: 1.19.4(zod@4.3.6)
       '@epic-web/invariant':
         specifier: 1.0.0
         version: 1.0.0
@@ -503,17 +503,17 @@ packages:
   '@colordx/core@5.0.3':
     resolution: {integrity: sha512-xBQ0MYRTNNxW3mS2sJtlQTT7C3Sasqgh1/PsHva7fyDb5uqYY+gv9V0utDdX8X80mqzbGz3u/IDJdn2d/uW09g==}
 
-  '@conform-to/dom@1.18.0':
-    resolution: {integrity: sha512-luccJjJJgvePp8mmU1plwEcofP0Gk/7a54ukSX1ta7K6J0Ep37nm18WK7gowrVCIHzCnR7iAdyjd+vGTpuI4zw==}
+  '@conform-to/dom@1.19.4':
+    resolution: {integrity: sha512-P/mBdVRl946iE74TXmF5YLY9+1IDrQzxKdj9A7qv7Cd4l/O02EvJskg3X7cHwhmFFIXXgNzSmf/y4B597SS4gg==}
 
-  '@conform-to/react@1.18.0':
-    resolution: {integrity: sha512-k5CnPa/a6YOv1+cavx5DiW4yh9RxC148Xxir5p3dqJ6r20WD9MvhVDOSJ/qmIegkYoLKQhxnOw3RJoNFfEDKPw==}
+  '@conform-to/react@1.19.4':
+    resolution: {integrity: sha512-Xyw4hbD9467q8PTWW+Nvmf523y814w70eeABRJzVvfnpghGOAWAGt1lpOboAs6sqaKG/eouqifibz/r+PDFZLg==}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  '@conform-to/zod@1.18.0':
-    resolution: {integrity: sha512-ombphsARN/7QpjOOsk7QPHDvCK1dLr4PlTz6styUQoh9vt8FxTOuH64XdY0XGtwUCTSJ5/9lvBa75cyhDbYm1Q==}
+  '@conform-to/zod@1.19.4':
+    resolution: {integrity: sha512-g80QtotXLcXWCF86Xou/VpI6i+NBOQxYgLS9YCQYrgV27yilZFJYpgWWBsA8YwodmJVBIYm9RawJba7WnUoddA==}
     peerDependencies:
       zod: ^3.21.0 || ^4.0.0
 
@@ -4406,17 +4406,17 @@ snapshots:
 
   '@colordx/core@5.0.3': {}
 
-  '@conform-to/dom@1.18.0': {}
+  '@conform-to/dom@1.19.4': {}
 
-  '@conform-to/react@1.18.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@conform-to/react@1.19.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@conform-to/dom': 1.18.0
+      '@conform-to/dom': 1.19.4
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@conform-to/zod@1.18.0(zod@4.3.6)':
+  '@conform-to/zod@1.19.4(zod@4.3.6)':
     dependencies:
-      '@conform-to/dom': 1.18.0
+      '@conform-to/dom': 1.19.4
       zod: 4.3.6
 
   '@electric-sql/pglite-socket@0.1.1(@electric-sql/pglite@0.4.1)':


### PR DESCRIPTION
Bumps `@conform-to/react` and `@conform-to/zod` from 1.18.0 to 1.19.4, which pulls the transitive `@conform-to/dom` up to 1.19.4 and resolves the high-severity Dependabot alert (CPU exhaustion in `parseSubmission` when parsing many unique form fields; patched in 1.19.4).

Verified with typecheck, tests (78 passing), and a production build.

Part of #93.