### PR TITLE
chore: bump pnpm to 11.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "node": ">=22.22.0"
   },
   "name": "cz.vednemesicnik",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.9.0",
   "private": true,
   "scripts": {
     "app:build": "react-router build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,12 @@
-onlyBuiltDependencies:
-  - '@prisma/client'
-  - '@prisma/engines'
-  - better-sqlite3
-  - esbuild
-  - lefthook
-  - prisma
-  - sharp
-  - unrs-resolver
+# pnpm 11 enforces a ~24h minimum-release-age supply-chain policy by default.
+# Disabled to preserve pnpm 10 install behavior (no release-age gating in CI/dev).
+minimumReleaseAge: 0
+
+# pnpm 11 replaces `onlyBuiltDependencies` (list) with `allowBuilds` (map).
+allowBuilds:
+  '@prisma/engines': true
+  better-sqlite3: true
+  esbuild: true
+  lefthook: true
+  prisma: true
+  sharp: true


### PR DESCRIPTION
Bumps the pinned package manager from `pnpm@10.33.0` to **`pnpm@11.9.0`**.

## Changes
- `packageManager` → `pnpm@11.9.0`
- **Build-script approval migration:** pnpm 11 no longer honors `onlyBuiltDependencies` (list) — it silently ignores build scripts, which breaks native deps (`better-sqlite3`, `@prisma/engines`, `sharp`, …). Migrated to the new `allowBuilds` (map) format.
- **Supply-chain policy:** pnpm 11 enables a default ~24h `minimumReleaseAge` policy that rejects any package version published within the last day. This blocked installs (fresh AWS-SDK `@smithy/*` / `iconv-lite` transitive deps already in the lockfile) and would intermittently break CI/Dependabot. Disabled it (`minimumReleaseAge: 0`) to preserve pnpm 10 behavior.

## Verification (all run with pnpm 11.9.0 via corepack)
- Native builds run (`better-sqlite3`, `@prisma/engines`, `esbuild`, `lefthook`, `prisma`)
- `app:typecheck` ✓ · `test` ✓ (78) · `app:build` ✓ · `prisma:generate` ✓
- `pnpm-lock.yaml` unchanged (no dependency resolution churn)

## Notes
- Contributors/CI now need pnpm 11 — the Dockerfiles already use `corepack ... --activate`, which honors the pinned `packageManager`, so no Docker change needed.
- Coordinated with the `donate-page` branch (which also touches pnpm config); that branch will be rebased onto this. The `allowBuilds` block matches; `minimumReleaseAge` handling differs by design (this disables it; donate-page uses `minimumReleaseAgeExclude`).

Part of #93.