### PR TITLE
chore(deps): override hono to 4.12.27

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  hono: 4.12.27
+
 importers:
 
   .:
@@ -874,7 +877,7 @@ packages:
     resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: 4.12.27
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -2576,8 +2579,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.9:
-    resolution: {integrity: sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==}
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.0:
@@ -4572,9 +4575,9 @@ snapshots:
 
   '@hexagon/base64@1.1.28': {}
 
-  '@hono/node-server@1.19.11(hono@4.12.9)':
+  '@hono/node-server@1.19.11(hono@4.12.27)':
     dependencies:
-      hono: 4.12.9
+      hono: 4.12.27
 
   '@img/colour@1.1.0': {}
 
@@ -4874,13 +4877,13 @@ snapshots:
       '@electric-sql/pglite': 0.4.1
       '@electric-sql/pglite-socket': 0.1.1(@electric-sql/pglite@0.4.1)
       '@electric-sql/pglite-tools': 0.3.1(@electric-sql/pglite@0.4.1)
-      '@hono/node-server': 1.19.11(hono@4.12.9)
+      '@hono/node-server': 1.19.11(hono@4.12.27)
       '@prisma/get-platform': 7.2.0
       '@prisma/query-plan-executor': 7.2.0
       '@prisma/streams-local': 0.1.2
       foreground-child: 3.3.1
       get-port-please: 3.2.0
-      hono: 4.12.9
+      hono: 4.12.27
       http-status-codes: 2.3.0
       pathe: 2.0.3
       proper-lockfile: 4.1.2
@@ -6322,7 +6325,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.9: {}
+  hono@4.12.27: {}
 
   http-errors@2.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,3 +10,9 @@ allowBuilds:
   lefthook: true
   prisma: true
   sharp: true
+
+# Force a patched hono. It is pulled only by dev/CLI tooling
+# (prisma -> @prisma/dev -> @hono/node-server -> hono), and prisma 7.8.0 (latest)
+# still resolves the vulnerable hono 4.12.9. Remove once prisma ships a fixed hono.
+overrides:
+  hono: 4.12.27


### PR DESCRIPTION
Adds a `pnpm` override forcing `hono` to **4.12.27** to clear the 9 open `hono` Dependabot alerts (high/medium).

## Why an override (not a parent bump)
`hono` is pulled only via dev/CLI tooling: `prisma` → `@prisma/dev` → `@hono/node-server` → `hono`. `prisma` is already at the latest release (7.8.0), which still resolves the vulnerable `hono@4.12.9` — so there is no parent bump available. The #93 plan anticipated this fallback. hono is **not** in the app runtime (that uses `@prisma/client` + `@prisma/adapter-better-sqlite3`), so the real-world exposure is dev-only, but this clears the alert board.

- Override target `4.12.27` satisfies the required `>= 4.12.25` (same major, patch-level).
- Remove the override once `prisma` ships a release that pulls a fixed hono.

## Verification (pnpm 11.9.0)
- `hono` resolves to 4.12.27 (4.12.9 gone)
- `app:typecheck` ✓ · `test` ✓ (78) · `app:build` ✓ · `prisma:generate` ✓

Part of #93.