### PR TITLE
fix(deploy): stop pnpm 11 reinstalling dev deps at container startup

### DIFF
--- a/docker/fly/Dockerfile
+++ b/docker/fly/Dockerfile
@@ -63,6 +63,10 @@ RUN chmod +x /usr/local/bin/database-cli
 WORKDIR /app
 
 COPY --from=production-deps /app/node_modules /app/node_modules
+# pnpm-workspace.yaml carries verifyDepsBeforeRun: false, which stops pnpm 11
+# from reinstalling the full (dev) dependency tree over the network when the
+# entrypoint runs `pnpm prisma:migrate:deploy` at startup.
+COPY --from=build /app/pnpm-workspace.yaml /app/pnpm-workspace.yaml
 COPY --from=build /app/build /app/build
 COPY --from=build /app/generated /app/generated
 COPY --from=build /app/package.json /app/package.json

--- a/docker/local/Dockerfile
+++ b/docker/local/Dockerfile
@@ -67,6 +67,10 @@ RUN chmod +x /usr/local/bin/seed-owner
 WORKDIR /app
 
 COPY --from=production-deps /app/node_modules /app/node_modules
+# pnpm-workspace.yaml carries verifyDepsBeforeRun: false, which stops pnpm 11
+# from reinstalling the full (dev) dependency tree over the network when the
+# entrypoint runs `pnpm prisma:migrate:deploy` at startup.
+COPY --from=build /app/pnpm-workspace.yaml /app/pnpm-workspace.yaml
 COPY --from=build /app/build /app/build
 COPY --from=build /app/generated /app/generated
 COPY --from=build /app/package.json /app/package.json

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,13 @@
 # Disabled to preserve pnpm 10 install behavior (no release-age gating in CI/dev).
 minimumReleaseAge: 0
 
+# pnpm 11 defaults this to "install": before running a script it verifies
+# node_modules against the lockfile and reinstalls anything missing. The
+# production Docker image ships a prod-only node_modules on purpose, so at
+# container startup this would wrongly reinstall the full dev dependency tree
+# over the network. Disabled to preserve pnpm 10 behavior (no pre-run check).
+verifyDepsBeforeRun: false
+
 # pnpm 11 replaces `onlyBuiltDependencies` (list) with `allowBuilds` (map).
 allowBuilds:
   '@prisma/engines': true


### PR DESCRIPTION
## Problem

Deploys to Fly were failing at container startup. The entrypoint runs `pnpm prisma:migrate:deploy`, and under **pnpm 11** `pnpm run <script>` first verifies `node_modules` against the lockfile. Its default, `verifyDepsBeforeRun: "install"`, then reinstalls anything missing.

The production image intentionally ships a **prod-only** `node_modules` (`pnpm install --prod`), so pnpm saw it as out of sync with the full lockfile and re-downloaded the entire dev dependency tree (Storybook, TypeScript, react-dom, …) over the network at startup. On Fly this hung on registry timeouts and OOM-killed the 1 GB machine before the server could start.

## Fix

- Set `verifyDepsBeforeRun: false` in `pnpm-workspace.yaml`, next to the existing pnpm-10-parity settings (`minimumReleaseAge: 0`, `allowBuilds`, `overrides`). pnpm 11 reads this setting **only** from `pnpm-workspace.yaml` or a `pnpm_config_*` env var — not from `.npmrc` or `npm_config_*`.
- Copy `pnpm-workspace.yaml` into the runtime image in both `docker/fly/Dockerfile` and `docker/local/Dockerfile` so the setting applies at startup.

The entrypoint scripts stay unchanged and readable (`pnpm prisma:migrate:deploy` / `pnpm app:start`).

## Verification

- **Local Docker:** entrypoint went straight to `prisma migrate deploy` → "No pending migrations" → server on `0.0.0.0:8080`; `/health` returned HTTP 200. No "Verifying lockfile" step, no reinstall.
- **Fly:** deployed successfully; new machine booted straight into `prisma migrate deploy` (no downloads), server came up, health check passing, serving real traffic. `https://vednemesicnik.cz/` returns HTTP 200.