### PR TITLE
fix(auth): disable sign-in submit buttons while pending

### DIFF
--- a/app/routes/administration/sign-in/magic-link/route.tsx
+++ b/app/routes/administration/sign-in/magic-link/route.tsx
@@ -1,7 +1,7 @@
 // noinspection JSUnusedGlobalSymbols
 import { getFormProps, getInputProps, useForm } from '@conform-to/react'
 import { getZodConstraint, parseWithZod } from '@conform-to/zod/v4'
-import { Link } from 'react-router'
+import { Link, useNavigation } from 'react-router'
 
 import { AdminButton } from '~/components/admin/admin-button'
 import { AdminInput } from '~/components/admin/admin-input'
@@ -32,6 +32,9 @@ export default function RouteComponent({ actionData }: Route.ComponentProps) {
     shouldRevalidate: 'onBlur',
     shouldValidate: 'onSubmit',
   })
+
+  const navigation = useNavigation()
+  const isSubmitting = navigation.state !== 'idle'
 
   const sent = actionData?.sent === true
 
@@ -67,8 +70,12 @@ export default function RouteComponent({ actionData }: Route.ComponentProps) {
                 placeholder={'vas-email@vednemesicnik.cz'}
               />
 
-              <AdminButton className={styles.button} type="submit">
-                Poslat odkaz
+              <AdminButton
+                className={styles.button}
+                disabled={isSubmitting}
+                type="submit"
+              >
+                {isSubmitting ? 'Odesílám…' : 'Poslat odkaz'}
               </AdminButton>
             </Form>
           </>

--- a/app/routes/administration/sign-in/magic-link/verify/route.tsx
+++ b/app/routes/administration/sign-in/magic-link/verify/route.tsx
@@ -1,5 +1,5 @@
 // noinspection JSUnusedGlobalSymbols
-import { Form, Link } from 'react-router'
+import { Form, Link, useNavigation } from 'react-router'
 
 import { AdminButton } from '~/components/admin/admin-button'
 import { HoneypotInputs } from '~/components/honeypot-inputs'
@@ -12,6 +12,9 @@ export { loader } from './_loader'
 export { meta } from './_meta'
 
 export default function RouteComponent({ loaderData }: Route.ComponentProps) {
+  const navigation = useNavigation()
+  const isSubmitting = navigation.state !== 'idle'
+
   if (loaderData.status === 'invalid') {
     return (
       <div className={styles.container}>
@@ -51,8 +54,12 @@ export default function RouteComponent({ loaderData }: Route.ComponentProps) {
           <input name={'token'} type={'hidden'} value={loaderData.token} />
           <input name={'email'} type={'hidden'} value={loaderData.email} />
 
-          <AdminButton className={styles.button} type="submit">
-            Přihlásit se
+          <AdminButton
+            className={styles.button}
+            disabled={isSubmitting}
+            type="submit"
+          >
+            {isSubmitting ? 'Přihlašuji…' : 'Přihlásit se'}
           </AdminButton>
         </Form>
       </section>

--- a/app/routes/administration/sign-in/password/route.tsx
+++ b/app/routes/administration/sign-in/password/route.tsx
@@ -2,7 +2,7 @@
 import { getFormProps, getInputProps, useForm } from '@conform-to/react'
 import { getZodConstraint, parseWithZod } from '@conform-to/zod/v4'
 import { useEffect, useRef } from 'react'
-import { Link } from 'react-router'
+import { Link, useNavigation } from 'react-router'
 import { AdminButton } from '~/components/admin/admin-button'
 import { AdminInput } from '~/components/admin/admin-input'
 import { Form } from '~/components/form'
@@ -18,6 +18,8 @@ export { meta } from './_meta'
 
 export default function RouteComponent({ actionData }: Route.ComponentProps) {
   const isHydrated = useHydrated()
+  const navigation = useNavigation()
+  const isSubmitting = navigation.state !== 'idle'
   const passwordInputRef = useRef<HTMLInputElement>(null)
 
   const [form, fields] = useForm({
@@ -76,8 +78,12 @@ export default function RouteComponent({ actionData }: Route.ComponentProps) {
             placeholder={'••••••••'}
           />
 
-          <AdminButton className={styles.button} type="submit">
-            Přihlásit se
+          <AdminButton
+            className={styles.button}
+            disabled={isSubmitting}
+            type="submit"
+          >
+            {isSubmitting ? 'Přihlašuji…' : 'Přihlásit se'}
           </AdminButton>
         </Form>
 

--- a/docs/_deploy-to-fly.md
+++ b/docs/_deploy-to-fly.md
@@ -19,6 +19,30 @@ fly secrets set SESSION_SECRET=$(openssl rand -hex 32) HONEYPOT_SECRET=$(openssl
 fly deploy
 ```
 
+## Sign-in secrets
+
+Magic-link sign-in needs the Google Apps Script web app credentials (see the
+`SCRIPT__Auth__Magic_Link` repo). `GAS_MAGIC_LINK_SECRET` must equal the script's
+`SHARED_SECRET` property.
+
+```shell
+fly secrets set GAS_MAGIC_LINK_URL="https://script.google.com/macros/s/.../exec" GAS_MAGIC_LINK_SECRET="…" --app cz-vednemesicnik
+```
+
+### Break-glass password (`ALLOW_PASSWORD_SIGN_IN`)
+
+Password sign-in is a last-resort emergency path, disabled by default. It's a Fly
+secret (not `fly.toml`) so it can be flipped with a restart instead of a redeploy.
+Any value other than `true` — including unset — is disabled.
+
+```shell
+# Enable (e.g. magic-link/GAS is down and you need in)
+fly secrets set ALLOW_PASSWORD_SIGN_IN=true --app cz-vednemesicnik
+
+# Disable
+fly secrets unset ALLOW_PASSWORD_SIGN_IN --app cz-vednemesicnik
+```
+
 ## Image store
 
 Pre-generated image variants are served as static files from `/data/images` on the

--- a/fly.toml
+++ b/fly.toml
@@ -17,10 +17,6 @@ primary_region = 'fra'
   # on-disk Fly volume (see docs/_deploy-to-fly.md → Object storage); change here
   # and `fly deploy`.
   STORE_DRIVER = 'tigris'
-  # Break-glass password sign-in (non-secret toggle). Kept 'true' so the password
-  # remains the only working sign-in method until an alternative ships (magic link
-  # / OAuth). Flip to 'false' once an alternative is deployed. See issue #112.
-  ALLOW_PASSWORD_SIGN_IN = 'true'
 
 [[mounts]]
   source = 'data'


### PR DESCRIPTION
Follow-up to #121 (magic-link sign-in). The submit buttons on the magic-link **request**, **password**, and magic-link **verify-confirm** forms weren't disabled during submission, so they could be double-submitted.

Each now uses `useNavigation()` to disable the button and show a pending label (`Odesílám…` / `Přihlašuji…`) while the submission is in flight.

## Verification
- Biome ✅ · typecheck ✅ · 115 tests ✅
- Manually: submitting a request keeps the button disabled until the response.