### PR TITLE
fix(auth): stop passkey ceremony re-triggering in a loop

### DIFF
--- a/app/routes/administration/settings/profile/passkeys/components/register-passkey/_component.tsx
+++ b/app/routes/administration/settings/profile/passkeys/components/register-passkey/_component.tsx
@@ -1,5 +1,5 @@
 import { startRegistration } from '@simplewebauthn/browser'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useFetcher, useRevalidator } from 'react-router'
 
 import { AdminButton } from '~/components/admin/admin-button'
@@ -22,12 +22,21 @@ export const RegisterPasskey = () => {
 
   const options = generateRegistrationOptionsFetcher.data?.options ?? null
 
+  // Tracks the challenge already handed to the authenticator so re-renders
+  // (fetcher state changes, revalidation) don't re-run the ceremony.
+  const startedOptionsRef = useRef<typeof options>(null)
+
   // Once the server returns the challenge, run the authenticator ceremony and
   // POST the attestation for verification (which persists the Passkey row).
   useEffect(() => {
     if (options === null) {
       return
     }
+
+    if (startedOptionsRef.current === options) {
+      return
+    }
+    startedOptionsRef.current = options
 
     const register = async () => {
       try {

--- a/app/routes/administration/sign-in/components/passkey-form/_component.tsx
+++ b/app/routes/administration/sign-in/components/passkey-form/_component.tsx
@@ -1,5 +1,5 @@
 import { startAuthentication } from '@simplewebauthn/browser'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useFetcher } from 'react-router'
 
 import type { action as generateAuthenticationOptionsAction } from '~/routes/administration/sign-in/passkey/generate-authentication-options/_action'
@@ -23,6 +23,10 @@ export const PasskeyForm = () => {
 
   const options = generateAuthenticationOptionsFetcher.data?.options ?? null
 
+  // Tracks the challenge already handed to the authenticator so re-renders
+  // (fetcher state changes before the redirect lands) don't re-run the ceremony.
+  const startedOptionsRef = useRef<typeof options>(null)
+
   // Once the server returns the challenge, run the authenticator ceremony and
   // POST the assertion for verification. A successful verify redirects into the
   // administration (session created server-side), so there is no success branch
@@ -31,6 +35,11 @@ export const PasskeyForm = () => {
     if (options === null) {
       return
     }
+
+    if (startedOptionsRef.current === options) {
+      return
+    }
+    startedOptionsRef.current = options
 
     const authenticate = async () => {
       try {


### PR DESCRIPTION
## Problem

Testing passkeys in Chrome revealed a loop in **both** WebAuthn flows:

- **Registration** (`/administration/settings/profile/passkeys`): after adding a single passkey, the native prompt immediately reopened and repeated until the user cancelled it manually — ending up with several passkeys registered.
- **Sign-in** (`/administration/sign-in`): after a successful sign-in and redirect into the administration, a new passkey sign-in prompt popped up again.

## Cause

Both components run the WebAuthn ceremony (`startRegistration` / `startAuthentication`) inside a `useEffect` whose dependency array included the verify **fetcher object**. `useFetcher()` returns a new reference on every state change / re-render, so after `submit()` (and, for registration, after `revalidator.revalidate()`) the effect re-ran. The `if (options === null) return` guard did not stop it, because `options` stays populated after success → an endless prompt loop.

The fetcher couldn't simply be removed from the deps — Biome has `useExhaustiveDependencies: "error"`.

## Fix

Added a `useRef` (`startedOptionsRef`) that records the `options` object already handed to the authenticator, so the ceremony runs **exactly once per challenge**. The dependency array is left unchanged (lint-clean); the ref also prevents a double run under React StrictMode. A fresh button click sends a new POST → a new `options` object → the guard passes → adding another passkey keeps working.

Related to #112.

## Verification

- `pnpm app:typecheck` and `pnpm biome:lint` — clean.
- Manually in Chrome: registration and sign-in each run once with no repeated prompt; the error path (dismissing the prompt) still works.
