### PR TITLE
feat(auth): passkey sign-in honors redirectTo

### DIFF
--- a/app/routes/administration/sign-in/components/passkey-form/_component.tsx
+++ b/app/routes/administration/sign-in/components/passkey-form/_component.tsx
@@ -11,7 +11,11 @@ import styles from '../../_styles.module.css'
 const ERROR_MESSAGE =
   'Přihlášení pomocí passkey se nezdařilo. Zkuste to prosím znovu.'
 
-export const PasskeyForm = () => {
+type Props = {
+  redirectTo: string
+}
+
+export const PasskeyForm = ({ redirectTo }: Props) => {
   const { isBiometricSupported } = useBiometric()
 
   const generateAuthenticationOptionsFetcher =
@@ -97,6 +101,7 @@ export const PasskeyForm = () => {
         method={'post'}
         onSubmit={() => setError(null)}
       >
+        <input name={'redirectTo'} type={'hidden'} value={redirectTo} />
         <button
           className={styles.googleButton}
           disabled={isPending}

--- a/app/routes/administration/sign-in/passkey/generate-authentication-options/_action.ts
+++ b/app/routes/administration/sign-in/passkey/generate-authentication-options/_action.ts
@@ -2,8 +2,14 @@ import { generateAuthenticationOptions } from '@simplewebauthn/server'
 import { type ActionFunctionArgs, data } from 'react-router'
 
 import { setBiometricCookieSession } from '~/utils/biometric.server'
+import { safeRedirect } from '~/utils/safe-redirect'
 
 export const action = async ({ request }: ActionFunctionArgs) => {
+  // Carried through the ceremony so verification can return the user to the page
+  // they came from; sanitized here and again in signInUser (defense-in-depth).
+  const formData = await request.formData()
+  const redirectTo = safeRedirect(formData.get('redirectTo'))
+
   const options = await generateAuthenticationOptions({
     // Usernameless / discoverable login: the authenticator presents its own
     // resident credentials, so the request is not scoped to a specific user.
@@ -21,6 +27,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
         'Set-Cookie': await setBiometricCookieSession(
           request,
           options.challenge,
+          redirectTo,
         ),
       },
     },

--- a/app/routes/administration/sign-in/passkey/verify-authentication-response/_action.ts
+++ b/app/routes/administration/sign-in/passkey/verify-authentication-response/_action.ts
@@ -5,6 +5,7 @@ import {
   deleteBiometricCookieSession,
   getBiometricChallenge,
   getBiometricCookieSession,
+  getBiometricRedirectTo,
 } from '~/utils/biometric.server'
 import { prisma } from '~/utils/db.server'
 import { signInUser } from '~/utils/sign-in.server'
@@ -14,6 +15,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   const biometricCookieSession = await getBiometricCookieSession(request)
   const biometricChallenge = getBiometricChallenge(biometricCookieSession)
+  const redirectTo = getBiometricRedirectTo(biometricCookieSession)
 
   const passkey = await prisma.passkey.findUnique({
     select: {
@@ -62,5 +64,5 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     'Set-Cookie': await deleteBiometricCookieSession(biometricCookieSession),
   })
 
-  return await signInUser(request, passkey.userId, undefined, headers)
+  return await signInUser(request, passkey.userId, redirectTo, headers)
 }

--- a/app/routes/administration/sign-in/route.tsx
+++ b/app/routes/administration/sign-in/route.tsx
@@ -43,7 +43,7 @@ export default function RouteComponent({ loaderData }: Route.ComponentProps) {
           </button>
         </form>
 
-        <PasskeyForm />
+        <PasskeyForm redirectTo={loaderData.redirectTo} />
 
         <Link
           className={styles.linkButton}

--- a/app/utils/biometric.server.ts
+++ b/app/utils/biometric.server.ts
@@ -5,9 +5,11 @@ import {
 } from 'react-router'
 
 const BIOMETRIC_CHALLENGE_KEY = 'biometricChallenge'
+const REDIRECT_TO_KEY = 'redirectTo'
 
 type BiometricCookieData = {
   [BIOMETRIC_CHALLENGE_KEY]: string
+  [REDIRECT_TO_KEY]: string
 }
 
 type BiometricCookieFlashData = {
@@ -39,10 +41,13 @@ export const getBiometricCookieSession = async (request: Request) =>
 export const setBiometricCookieSession = async (
   request: Request,
   biometricChallenge: string,
+  // Only the sign-in ceremony carries a return path; registration omits it.
+  redirectTo = '',
 ) => {
   const cookieSession = await getBiometricCookieSession(request)
 
   cookieSession.set(BIOMETRIC_CHALLENGE_KEY, biometricChallenge)
+  cookieSession.set(REDIRECT_TO_KEY, redirectTo)
 
   return cookieSessionStorage.commitSession(cookieSession)
 }
@@ -53,3 +58,6 @@ export const deleteBiometricCookieSession = async (
 
 export const getBiometricChallenge = (cookieSession: BiometricCookieSession) =>
   cookieSession.get(BIOMETRIC_CHALLENGE_KEY)
+
+export const getBiometricRedirectTo = (cookieSession: BiometricCookieSession) =>
+  cookieSession.get(REDIRECT_TO_KEY)


### PR DESCRIPTION
Closes #134. Sub-issue of #112 (follow-up to Phase 5 / #117).

## Problem

After sign-in, the user should land back on the page they came from. Only **Google OAuth** threaded `redirectTo`; passkey sign-in always redirected to `/administration`, discarding the original destination that `requireAuthentication` had captured (`/administration/sign-in?redirectTo=<path>`).

## Change

Carry `redirectTo` through the passkey ceremony via the existing `vdm_biometric` cookie — mirroring how OAuth uses its transient `vdm_oauth` cookie — so the value stays server-side (HttpOnly) and is re-validated with `safeRedirect` at both boundaries.

- `biometric.server.ts` — store `redirectTo` alongside the challenge; add `getBiometricRedirectTo` (param is optional so passkey **registration** in settings still works unchanged).
- `generate-authentication-options/_action.ts` — read + `safeRedirect` the form field, store it.
- `passkey-form` component + sign-in `route.tsx` — pass `redirectTo` down and add a hidden input to the generate form (same pattern as the Google form).
- `verify-authentication-response/_action.ts` — read it from the cookie and pass to `signInUser` (which re-sanitizes as defense-in-depth).

Magic link / password parity is intentionally out of scope.

## Verification

- `pnpm app:typecheck` + `pnpm test` (137 passing).
- Manual: signed out, open a protected page → bounced to sign-in with `redirectTo` → sign in with passkey → land back on the original page.
- `redirectTo=//evil.com` falls back to `/administration` (open-redirect guard).
- Direct visit to sign-in (no `redirectTo`) still lands on `/administration`.