### PR TITLE
feat(security): per-IP rate limiting for password & verify-2fa sign-in (#128)

### DIFF
--- a/app/routes/administration/sign-in/password/_action.ts
+++ b/app/routes/administration/sign-in/password/_action.ts
@@ -1,17 +1,20 @@
 import { parseWithZod } from '@conform-to/zod/v4'
 import bcrypt from 'bcryptjs'
-import { type ActionFunctionArgs, data, redirect } from 'react-router'
+import { data, redirect } from 'react-router'
 
 import { setSessionAuthCookieSession } from '~/utils/auth.server'
 import { prisma } from '~/utils/db.server'
+import { formatRetryAfter } from '~/utils/format-retry-after'
 import { checkHoneypot } from '~/utils/honeypot.server'
 import { setPendingTwoFactorCookieSession } from '~/utils/pending-two-factor.server'
+import { rateLimitContext } from '~/utils/rate-limit.server'
 import { createSession } from '~/utils/session.server'
 import { getUserTwoFactor } from '~/utils/two-factor.server'
 
 import { schema } from './_schema'
+import type { Route } from './+types/route'
 
-export const action = async ({ request }: ActionFunctionArgs) => {
+export const action = async ({ request, context }: Route.ActionArgs) => {
   const formData = await request.formData()
 
   checkHoneypot(formData)
@@ -23,6 +26,28 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     // 303 See Other: turn this POST rejection into a GET redirect so the client
     // cannot retry with POST semantics.
     throw redirect('/administration/sign-in', { status: 303 })
+  }
+
+  // Rate limited by the middleware (see _middleware.ts): surface an inline error
+  // before verifying the password, so brute-forcing is bounded per IP. Only
+  // relevant on the enabled break-glass path, so it runs after the gate above.
+  const limited = context.get(rateLimitContext)
+  if (limited) {
+    const submission = await parseWithZod(formData, { async: true, schema })
+    return data(
+      {
+        authenticationOptions: null,
+        isAuthenticated: false,
+        registrationOptions: null,
+        submissionResult: submission.reply({
+          formErrors: [
+            `Příliš mnoho pokusů. Zkuste to prosím ${formatRetryAfter(limited.retryAfter)}.`,
+          ],
+          hideFields: ['password'],
+        }),
+      },
+      { status: 429 },
+    )
   }
 
   const submission = await parseWithZod(formData, {

--- a/app/routes/administration/sign-in/password/_middleware.ts
+++ b/app/routes/administration/sign-in/password/_middleware.ts
@@ -1,0 +1,11 @@
+import { createRateLimitMiddleware } from '~/utils/rate-limit.server'
+
+import type { Route } from './+types/route'
+
+export const middleware: Route.MiddlewareFunction[] = [
+  createRateLimitMiddleware({
+    key: 'password-sign-in',
+    limit: 10,
+    windowMs: 15 * 60 * 1000, // 10 attempts per 15 minutes per IP
+  }),
+]

--- a/app/routes/administration/sign-in/password/route.tsx
+++ b/app/routes/administration/sign-in/password/route.tsx
@@ -15,6 +15,7 @@ import type { Route } from './+types/route'
 export { action } from './_action'
 export { loader } from './_loader'
 export { meta } from './_meta'
+export { middleware } from './_middleware'
 
 export default function RouteComponent({ actionData }: Route.ComponentProps) {
   const isHydrated = useHydrated()

--- a/app/routes/administration/sign-in/verify-2fa/_action.ts
+++ b/app/routes/administration/sign-in/verify-2fa/_action.ts
@@ -1,8 +1,9 @@
 import { parseWithZod } from '@conform-to/zod/v4'
-import { type ActionFunctionArgs, data, redirect } from 'react-router'
+import { data, redirect } from 'react-router'
 
 import { setSessionAuthCookieSession } from '~/utils/auth.server'
 import { redeemBackupCode } from '~/utils/backup-codes.server'
+import { formatRetryAfter } from '~/utils/format-retry-after'
 import { checkHoneypot } from '~/utils/honeypot.server'
 import {
   deletePendingTwoFactorCookieSession,
@@ -12,13 +13,15 @@ import {
   MAX_TWO_FACTOR_ATTEMPTS,
   setPendingTwoFactorCookieSession,
 } from '~/utils/pending-two-factor.server'
+import { rateLimitContext } from '~/utils/rate-limit.server'
 import { createSession } from '~/utils/session.server'
 import { verifyTOTP } from '~/utils/totp.server'
 import { getUserTwoFactor } from '~/utils/two-factor.server'
 
 import { schema } from './_schema'
+import type { Route } from './+types/route'
 
-export const action = async ({ request }: ActionFunctionArgs) => {
+export const action = async ({ request, context }: Route.ActionArgs) => {
   const formData = await request.formData()
 
   checkHoneypot(formData)
@@ -45,6 +48,25 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   // No pending sign-in — restart from the password step.
   if (userId === undefined) {
     throw await redirectToPassword()
+  }
+
+  // Rate limited by the middleware (see _middleware.ts): surface an inline error
+  // before verifying the code, bounding TOTP / backup-code brute-forcing and the
+  // bcrypt cost of failed backup-code attempts per IP. Only relevant on the
+  // enabled break-glass path, so it runs after the gate / pending-session guards.
+  const limited = context.get(rateLimitContext)
+  if (limited) {
+    const submission = await parseWithZod(formData, { async: true, schema })
+    return data(
+      {
+        submissionResult: submission.reply({
+          formErrors: [
+            `Příliš mnoho pokusů. Zkuste to prosím ${formatRetryAfter(limited.retryAfter)}.`,
+          ],
+        }),
+      },
+      { status: 429 },
+    )
   }
 
   const submission = await parseWithZod(formData, { async: true, schema })

--- a/app/routes/administration/sign-in/verify-2fa/_middleware.ts
+++ b/app/routes/administration/sign-in/verify-2fa/_middleware.ts
@@ -1,0 +1,11 @@
+import { createRateLimitMiddleware } from '~/utils/rate-limit.server'
+
+import type { Route } from './+types/route'
+
+export const middleware: Route.MiddlewareFunction[] = [
+  createRateLimitMiddleware({
+    key: 'verify-2fa',
+    limit: 10,
+    windowMs: 15 * 60 * 1000, // 10 attempts per 15 minutes per IP
+  }),
+]

--- a/app/routes/administration/sign-in/verify-2fa/route.tsx
+++ b/app/routes/administration/sign-in/verify-2fa/route.tsx
@@ -14,6 +14,7 @@ import type { Route } from './+types/route'
 export { action } from './_action'
 export { loader } from './_loader'
 export { meta } from './_meta'
+export { middleware } from './_middleware'
 
 export default function RouteComponent({ actionData }: Route.ComponentProps) {
   const isHydrated = useHydrated()


### PR DESCRIPTION
## Why

`POST /administration/sign-in/password` and `POST /administration/sign-in/verify-2fa` had no per-IP rate limiting. On the enabled break-glass path (`ALLOW_PASSWORD_SIGN_IN=true`):

- **password** allowed unlimited online password guessing, each attempt costing a bcrypt compare.
- **verify-2fa** could be brute-forced by looping "submit password → get a fresh pending-2FA cookie → burn the cookie's 5-attempt counter → repeat" against the 6-digit TOTP or single-use backup codes (a failed backup-code attempt also runs up to 10 `bcrypt.compareSync` calls).

## What

- New `_middleware.ts` on each route reusing the existing `createRateLimitMiddleware` (10 attempts / 15 min per IP), mirroring the magic-link pattern, plus `export { middleware }` from each `route.tsx`.
- Both actions read `rateLimitContext` **after** the break-glass gate / pending-session guards (the limiter is only relevant while the break-glass flow is enabled) and surface an inline `429` with a Czech message, so the error renders in the form rather than the ErrorBoundary.
- No new infrastructure; the in-memory/per-instance limitation is already documented in `rate-limit.server.ts`.

## Verification

`pnpm app:typecheck` and `pnpm test` (137 passed) pass. Against `pnpm app:dev` with the flag on:

- password: `400 ×10 → 429` with `RateLimit-*` + `Retry-After: 900`.
- verify-2fa (with a valid pending-2FA cookie): `303 ×10 → 429`, `Retry-After: 900`, and the form shows "Příliš mnoho pokusů. Zkuste to prosím za 15 minut."
- Magic-link and Google sign-in unchanged.

Closes #128