### PR TITLE
feat(security): password policy hardening (min length 8, bcrypt cost 12)

### DIFF
--- a/app/routes/administration/settings/profile/change-password/_schema.ts
+++ b/app/routes/administration/settings/profile/change-password/_schema.ts
@@ -1,14 +1,13 @@
 import { z } from 'zod'
 
-// TODO: change minimum password length to 8
 export const schema = z
   .object({
-    newPassword: z.string({ message: 'Heslo je povinné' }).min(5, {
-      message: 'Heslo musí mít alespoň 5 znaků',
+    newPassword: z.string({ message: 'Heslo je povinné' }).min(8, {
+      message: 'Heslo musí mít alespoň 8 znaků',
     }),
     newPasswordConfirmation: z
       .string({ message: 'Potvrzení hesla je povinné' })
-      .min(5, { message: 'Potvrzení hesla musí mít alespoň 5 znaků' }),
+      .min(8, { message: 'Potvrzení hesla musí mít alespoň 8 znaků' }),
     userId: z.string(),
   })
   .refine((data) => data.newPassword === data.newPasswordConfirmation, {

--- a/app/routes/administration/settings/profile/change-password/utils/change-password.server.ts
+++ b/app/routes/administration/settings/profile/change-password/utils/change-password.server.ts
@@ -7,7 +7,7 @@ export const changePassword = async (userId: string, newPassword: string) => {
   try {
     await prisma.password.update({
       data: {
-        hash: bcrypt.hashSync(newPassword, 10),
+        hash: bcrypt.hashSync(newPassword, 12),
       },
       where: {
         userId,

--- a/app/routes/administration/users/add-user/utils/create-user.server.ts
+++ b/app/routes/administration/users/add-user/utils/create-user.server.ts
@@ -53,7 +53,7 @@ export const createUser = async (data: Data) => {
           name: data.name,
           password: {
             create: {
-              hash: bcrypt.hashSync(data.password, 10),
+              hash: bcrypt.hashSync(data.password, 12),
             },
           },
           role: {

--- a/app/routes/administration/users/add-user/utils/create-user.server.ts
+++ b/app/routes/administration/users/add-user/utils/create-user.server.ts
@@ -23,6 +23,10 @@ type Data = DataWithNewAuthor | DataWithExistingAuthor
 
 export const createUser = async (data: Data) => {
   try {
+    // Hash outside the transaction: bcrypt is CPU-bound and would otherwise
+    // hold the SQLite transaction open, increasing lock contention.
+    const passwordHash = bcrypt.hashSync(data.password, 12)
+
     const user = await prisma.$transaction(async (prisma) => {
       let authorId: string
 
@@ -53,7 +57,7 @@ export const createUser = async (data: Data) => {
           name: data.name,
           password: {
             create: {
-              hash: bcrypt.hashSync(data.password, 12),
+              hash: passwordHash,
             },
           },
           role: {

--- a/app/routes/administration/users/user/edit-user/utils/update-user.ts
+++ b/app/routes/administration/users/user/edit-user/utils/update-user.ts
@@ -48,7 +48,7 @@ export const updateUser = async ({
             ? {
                 password: {
                   update: {
-                    hash: bcrypt.hashSync(password, 10),
+                    hash: bcrypt.hashSync(password, 12),
                   },
                 },
               }

--- a/app/routes/administration/users/user/edit-user/utils/update-user.ts
+++ b/app/routes/administration/users/user/edit-user/utils/update-user.ts
@@ -37,6 +37,11 @@ export const updateUser = async ({
     throwError('Unable to update the user.')
   }
 
+  // Hash outside the transaction: bcrypt is CPU-bound and would otherwise
+  // hold the SQLite transaction open, increasing lock contention.
+  const passwordHash =
+    password !== undefined ? bcrypt.hashSync(password, 12) : undefined
+
   try {
     await prisma.$transaction(async (prisma) => {
       const updatedUser = await prisma.user.update({
@@ -44,11 +49,11 @@ export const updateUser = async ({
           email,
           name,
           username: email,
-          ...(password !== undefined
+          ...(passwordHash !== undefined
             ? {
                 password: {
                   update: {
-                    hash: bcrypt.hashSync(password, 12),
+                    hash: passwordHash,
                   },
                 },
               }

--- a/app/utils/backup-codes.server.test.ts
+++ b/app/utils/backup-codes.server.test.ts
@@ -1,6 +1,10 @@
 import bcrypt from 'bcryptjs'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
+// These tests hash full code sets with real bcrypt at production cost (12),
+// which is deliberately slow; give them more headroom than the 5s default.
+vi.setConfig({ testTimeout: 30_000 })
+
 type Row = { id: string; codeHash: string; usedAt: Date | null; userId: string }
 
 // In-memory stand-in for the BackupCode table. The helpers run for real, so

--- a/app/utils/backup-codes.server.ts
+++ b/app/utils/backup-codes.server.ts
@@ -9,7 +9,7 @@ import { throwDbError } from '~/utils/throw-db-error.server'
 export const BACKUP_CODE_COUNT = 10
 
 // bcrypt cost factor, matching Password.hash.
-const BCRYPT_ROUNDS = 10
+const BCRYPT_ROUNDS = 12
 
 // Unambiguous alphabet — no 0/1 and no i/l/o — so codes are easy to read and
 // transcribe from the downloaded file.


### PR DESCRIPTION
Part of #126. Closes #129.

## Why

Two small inconsistencies in password handling flagged by the July 2026 auth security audit:

1. **Min length mismatch** — creating/editing a user requires ≥ 8 characters, but the change-password form only required ≥ 5 (with a stale `TODO` to raise it).
2. **bcrypt cost was 10** — current guidance is 12+ for new hashes.

## What

- **Change-password schema** (`change-password/_schema.ts`): raised the minimum from 5 → 8 for both fields, updated the Czech messages to match the add-user/edit-user schemas verbatim, and removed the stale `TODO`.
- **bcrypt cost 10 → 12** at every hashing call site:
  - `add-user/utils/create-user.server.ts`
  - `change-password/utils/change-password.server.ts`
  - `users/user/edit-user/utils/update-user.ts` — extra site found via `grep -rn bcrypt app/`, not listed in the issue
  - `backup-codes.server.ts` (`BCRYPT_ROUNDS`), keeping its "matching Password.hash" comment accurate
- Sign-in `_action.ts` files untouched (compare-only).

Cost is read from the stored hash on `compare`/`compareSync`, so existing `$2b$10$` hashes keep verifying — current users are unaffected. Only newly generated hashes use cost 12.

## Test note

Cost 12 makes real bcrypt hashing ~4× slower, which tripped two DB-persistence backup-code tests over the 5s default timeout. Fixed with a file-scoped `vi.setConfig({ testTimeout: 30_000 })` in `backup-codes.server.test.ts` — production cost stays at 12.

## Acceptance criteria

- [x] Changing a password to < 8 chars shows a Czech validation error.
- [x] New hashes use cost 12 (`$2b$12$` prefix).
- [x] Existing cost-10 hashes still verify (cost read from the stored hash).
- [x] `pnpm app:typecheck` and `pnpm test` pass (137 tests).

## Verification

Manual (dev): at `/administration/settings/profile`, a 5-char password is rejected and an 8-char one succeeds; confirm the new `Password.hash` starts with `$2b$12$` in Prisma Studio.