### PR TITLE
feat(security): require user verification for passkey ceremonies (#130)

### DIFF
--- a/app/routes/administration/settings/profile/passkeys/generate-registration-options/_action.ts
+++ b/app/routes/administration/settings/profile/passkeys/generate-registration-options/_action.ts
@@ -33,7 +33,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     authenticatorSelection: {
       authenticatorAttachment: 'platform',
       residentKey: 'preferred',
-      userVerification: 'preferred',
+      userVerification: 'required',
     },
     // Block registering an authenticator that is already enrolled.
     excludeCredentials: session.user.passkeys.map((passkey) => ({

--- a/app/routes/administration/settings/profile/passkeys/verify-registration-response/_action.ts
+++ b/app/routes/administration/settings/profile/passkeys/verify-registration-response/_action.ts
@@ -24,6 +24,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     expectedChallenge: biometricChallenge ?? '',
     expectedOrigin: process.env.RELYING_PARTY_ORIGIN ?? '',
     expectedRPID: process.env.RELYING_PARTY_ID ?? '',
+    requireUserVerification: true,
     response: body,
   })
 

--- a/app/routes/administration/sign-in/passkey/generate-authentication-options/_action.ts
+++ b/app/routes/administration/sign-in/passkey/generate-authentication-options/_action.ts
@@ -15,6 +15,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     // resident credentials, so the request is not scoped to a specific user.
     allowCredentials: [],
     rpID: process.env.RELYING_PARTY_ID ?? '',
+    userVerification: 'required',
   })
 
   return data(

--- a/app/routes/administration/sign-in/passkey/verify-authentication-response/_action.ts
+++ b/app/routes/administration/sign-in/passkey/verify-authentication-response/_action.ts
@@ -42,6 +42,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     expectedChallenge: biometricChallenge ?? '',
     expectedOrigin: process.env.RELYING_PARTY_ORIGIN ?? '',
     expectedRPID: process.env.RELYING_PARTY_ID ?? '',
+    requireUserVerification: true,
     response: body,
   })
 


### PR DESCRIPTION
Closes #130 (part of #126).

## Why

Passkey registration used `userVerification: 'preferred'`, and the verify calls relied on library defaults. "Preferred" lets an authenticator skip the biometric/PIN check, so possessing an unlocked authenticator could be enough to sign in to the administration. For an admin system, user verification (Touch ID / Windows Hello / PIN) should be explicitly **required** at both registration and authentication.

## Changes

- **generate-registration-options**: `authenticatorSelection.userVerification` `'preferred'` → `'required'`.
- **generate-authentication-options**: add `userVerification: 'required'`.
- **verify-registration-response**: add `requireUserVerification: true`.
- **verify-authentication-response**: add `requireUserVerification: true`.

The verify calls set `requireUserVerification` explicitly rather than depend on the `@simplewebauthn/server` 13.3.2 default — it documents intent and survives library upgrades.

## Compatibility

Registration is already restricted to platform authenticators (`authenticatorAttachment: 'platform'` — Touch ID, Windows Hello), which effectively always perform user verification, so passkeys registered before this change are expected to keep working.

## Verification

- `pnpm app:typecheck` passes.
- `pnpm test` passes (137 tests; no tests reference these actions).
- Manual (dev, `RELYING_PARTY_*` set for localhost): register a new passkey in `/administration/settings/profile`, sign out, sign in with it. Also test a passkey registered before this change if available.