### PR TITLE
ci: persistent dev branch model with automated back-merge

### DIFF
--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -7,6 +7,11 @@ on:
 permissions:
   contents: read
 
+# Serialize runs so two pushes in quick succession can't both create a PR.
+concurrency:
+  group: sync-dev
+  cancel-in-progress: false
+
 jobs:
   back-merge:
     runs-on: ubuntu-latest
@@ -21,6 +26,12 @@ jobs:
           # would sit as "expected" forever and block the merge.
           GH_TOKEN: ${{ secrets.BACKMERGE_TOKEN }}
         run: |
+          # dev may not exist yet (e.g. the merge that first introduces this
+          # workflow, before the branch is created). Nothing to sync until then.
+          if ! git show-ref --verify --quiet refs/remotes/origin/dev; then
+            echo "dev branch does not exist yet"
+            exit 0
+          fi
           behind=$(git rev-list --count origin/dev..origin/main)
           if [ "$behind" -eq 0 ]; then
             echo "dev is up to date with main"

--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -42,6 +42,12 @@ jobs:
             echo "dev is up to date with main"
             exit 0
           fi
+          # Surface a missing/expired token as a warning rather than a red run
+          # on main — the git checks above don't need it, only the gh calls do.
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::warning::BACKMERGE_TOKEN is not set; skipping back-merge PR"
+            exit 0
+          fi
           open=$(gh pr list --base dev --head main --state open --json number --jq length)
           if [ "$open" -gt 0 ]; then
             echo "back-merge PR already open"

--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -1,0 +1,36 @@
+name: Sync dev
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  back-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Open back-merge PR if dev is behind main
+        env:
+          # PAT, not GITHUB_TOKEN: PRs opened with the default workflow token do
+          # not trigger pull_request workflows, so the required CI checks (#143)
+          # would sit as "expected" forever and block the merge.
+          GH_TOKEN: ${{ secrets.BACKMERGE_TOKEN }}
+        run: |
+          behind=$(git rev-list --count origin/dev..origin/main)
+          if [ "$behind" -eq 0 ]; then
+            echo "dev is up to date with main"
+            exit 0
+          fi
+          open=$(gh pr list --base dev --head main --state open --json number --jq length)
+          if [ "$open" -gt 0 ]; then
+            echo "back-merge PR already open"
+            exit 0
+          fi
+          gh pr create --base dev --head main \
+            --title "chore: back-merge main into dev" \
+            --body "Automated back-merge to keep \`dev\` in sync with \`main\`."

--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -42,8 +42,10 @@ jobs:
             echo "dev is up to date with main"
             exit 0
           fi
-          # Surface a missing/expired token as a warning rather than a red run
-          # on main — the git checks above don't need it, only the gh calls do.
+          # Surface a *missing* token as a warning rather than a red run on main
+          # (the git checks above don't need it, only the gh calls do). A present
+          # but invalid/expired token is left to fail loudly — a red run is the
+          # signal to renew the PAT before dev silently drifts from main.
           if [ -z "$GH_TOKEN" ]; then
             echo "::warning::BACKMERGE_TOKEN is not set; skipping back-merge PR"
             exit 0

--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -26,12 +26,17 @@ jobs:
           # would sit as "expected" forever and block the merge.
           GH_TOKEN: ${{ secrets.BACKMERGE_TOKEN }}
         run: |
-          # dev may not exist yet (e.g. the merge that first introduces this
-          # workflow, before the branch is created). Nothing to sync until then.
-          if ! git show-ref --verify --quiet refs/remotes/origin/dev; then
+          # checkout only populates the triggering ref (main), so origin/dev is
+          # not present locally even when the branch exists on GitHub. Check the
+          # remote directly: if dev doesn't exist yet (e.g. the merge that first
+          # introduces this workflow, before the branch is created) there's
+          # nothing to sync.
+          if ! git ls-remote --exit-code --heads origin dev >/dev/null 2>&1; then
             echo "dev branch does not exist yet"
             exit 0
           fi
+          # Fetch dev explicitly into a tracking ref so the range below resolves.
+          git fetch --no-tags origin +refs/heads/dev:refs/remotes/origin/dev
           behind=$(git rev-list --count origin/dev..origin/main)
           if [ "$behind" -eq 0 ]; then
             echo "dev is up to date with main"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,13 @@ Install Git hooks for code quality automation:
 pnpm lefthook:install              # Install Lefthook Git hooks
 ```
 
+### Branching & Pull Requests
+
+`dev` is the default branch; `main` is production and the only deploy source. Branch
+off `dev` in kebab-case with the issue number (e.g. `feat/155-branching-model-dev`) and
+target `dev` in the PR. Releases (`dev → main`) and hotfixes target `main`. See
+`docs/_branching-model.md` for the full flow and merge-method conventions.
+
 ### Database Management
 
 ```bash
@@ -217,6 +224,7 @@ Comprehensive project documentation is in the `docs/` directory:
 - `docs/_author-roles-and-permissions.md` - Author role details
 - `docs/_content-creation-lifecycle.md` - Content states and transitions
 - `docs/_authentication-middleware.md` - Authentication architecture and future middleware migration plan
+- `docs/_branching-model.md` - Branching model, merge methods, hotfix procedure
 - `docs/_deploy-to-fly.md` - Deployment instructions
 - `docs/_manual-database-backup.md` - Database backup procedures
 - `docs/_manual-database-restore.md` - Database restore procedures

--- a/docs/_branching-model.md
+++ b/docs/_branching-model.md
@@ -1,0 +1,60 @@
+# Branching Model
+
+The repository uses a persistent `dev` integration branch to decouple **merging a
+feature** from **deploying to production**. Merges to `main` deploy; merges to `dev`
+do not.
+
+- `dev` is the **default branch** — feature, fix, and Dependabot PRs target it
+  automatically.
+- `main` is the **production branch** and the only deploy source.
+
+## Flow
+
+```
+feature/fix ──► dev ──(release)──► main ──► deploy
+                 ▲                   │
+                 └──(back-merge)─────┘
+
+hotfix ──────────────────────────► main ──► deploy
+                                     │
+                 dev ◄──(back-merge)─┘
+```
+
+- **Feature / fix:** branch off `dev`, PR back into `dev`. No deploy.
+- **Release:** PR `dev → main`. This is the only moment a deploy happens.
+- **Hotfix:** branch off `main`, PR directly into `main` (deploys), then back-merge
+  into `dev`.
+
+## Merge methods
+
+The merge method matters: squashing a `dev → main` release would rewrite the commits
+and permanently diverge the two branches.
+
+| PR | Method |
+| --- | --- |
+| feature/fix → `dev` | squash |
+| release `dev → main` | **merge commit** — squash would permanently diverge the branches |
+| hotfix → `main` | squash |
+| back-merge `main → dev` | **merge commit** |
+
+## Automated back-merge
+
+`.github/workflows/sync-dev.yml` runs on every push to `main`. If `dev` is behind, it
+opens a single PR `main → dev`; merging it stays a manual decision (merge commit).
+
+After every release merge (`dev → main` merge commit) `dev` is behind by exactly that
+merge commit, so the workflow opens a trivially mergeable back-merge PR. Merge it (merge
+commit) to keep the histories converged.
+
+The workflow uses a fine-grained PAT (`BACKMERGE_TOKEN`), not the default
+`GITHUB_TOKEN`: PRs created with the workflow token do not trigger `pull_request`
+workflows, so the required CI checks would sit as "expected" forever and block the
+merge. The token is scoped to this repo with **Contents: read** and **Pull requests:
+read & write**.
+
+## Hotfix procedure
+
+1. Branch off `main` (e.g. `fix/123-...`).
+2. PR into `main`, squash merge. This deploys.
+3. The push to `main` triggers `sync-dev.yml`, which opens a back-merge PR `main → dev`.
+   Merge it (merge commit) to carry the fix back into `dev`.


### PR DESCRIPTION
## Context

The epic auto-deploys every merge to `main` (#141), so "merge a feature" is coupled with "deploy to production". This PR lays the foundation from #155: a persistent `dev` integration branch that decouples the two.

- feature/fix branches → PR into `dev` (no deploy)
- release = PR `dev → main` (the only moment a deploy happens)
- hotfix branches → PR directly into `main`, then back-merged into `dev`

`dev` will become the **default branch** (feature/fix and Dependabot PRs target it automatically); `main` stays the production branch and the only deploy source.

This is the foundation for the CI triggers in #138 and the branch ruleset in #143.

## Changes

- **`.github/workflows/sync-dev.yml`** — on every push to `main`, opens a single back-merge PR `main → dev` when `dev` is behind. Uses a fine-grained PAT (`BACKMERGE_TOKEN`) instead of `GITHUB_TOKEN` so that `pull_request` CI actually runs on the back-merge PR (the default token would leave required checks stuck as "expected" and block the merge). Merging the PR stays a manual decision.
- **`docs/_branching-model.md`** — the flow, merge-method table, back-merge rationale, and hotfix procedure.
- **`AGENTS.md`** — new "Branching & Pull Requests" note (PR-target convention) and a docs-list entry.

## Landing order

This PR targets `main` directly (squash) so the workflow lands on `main` immediately. **After merge**, the GitHub-side bootstrap runs: create `dev` from the updated `main`, flip the default branch to `dev`, and add the `BACKMERGE_TOKEN` secret (fine-grained PAT scoped to this repo, Contents: read + Pull requests: read & write).

## Verification

- Push to `main` with `dev` behind → exactly one back-merge PR `main → dev`, with CI running on it; a repeated push opens no second PR.
- Push to `main` with `dev` up to date → workflow logs "dev is up to date with main", no PR.

Refs #155