### PR TITLE
ci: core PR checks workflow (lint, typecheck, test, build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main, dev]
+  workflow_call:
+
+permissions:
+  contents: read
+
+# Cancel stale runs on new pushes to a PR, but never cancel a run
+# that was started via workflow_call from the deploy workflow.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4 # reads version from packageManager field
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm biome:check
+
+  typecheck:
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: file:./data/sqlite.db
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm prisma:generate
+      - run: pnpm app:typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: file:./data/sqlite.db
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm prisma:generate
+      - run: pnpm test
+
+  build:
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: file:./data/sqlite.db
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm prisma:generate
+      - run: pnpm app:build


### PR DESCRIPTION
## Context

The repo has no CI — quality gates exist only as local lefthook hooks, which can be skipped with `--no-verify` and don't protect `main`/`dev`. This adds the core GitHub Actions workflow (#138) that runs on every PR and becomes the foundation the deploy workflow (#141) reuses via `workflow_call`.

## Changes

`.github/workflows/ci.yml` with four jobs, each installing with `--frozen-lockfile`:

- **lint** — `pnpm biome:check`
- **typecheck** — `prisma:generate` → `pnpm app:typecheck`
- **test** — `prisma:generate` → `pnpm test`
- **build** — `prisma:generate` → `pnpm app:build`

Triggers on `pull_request` against `main`/`dev` and on `workflow_call` (for #141). Concurrency cancels stale PR runs but never a `workflow_call` run.

## Notes

- Job names are kept exactly `lint`/`typecheck`/`test`/`build` — they become required status checks in #143.
- pnpm version comes from `packageManager: pnpm@11.9.0`, not a hardcoded pin.
- `prisma:generate` runs before the type-aware steps (client is generated into `generated/`, imported via `@generated/*`).
- **`node-version: 26`**, not the `24` from the original issue snippet — the repo was upgraded to Node LTS 26 (`engines.node >= 26`, `.nvmrc` = 26) after the issue was written.

## Verification

All four commands pass locally on this branch (biome ✅, typecheck ✅, test 137/137 ✅, build ✅). This PR against `dev` exercises the workflow end-to-end; the checks below should all go green.

Refs #138