### PR TITLE
ci: bump pnpm/action-setup to v6; document back-merge auto-delete pitfall

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4 # reads version from packageManager field
+      - uses: pnpm/action-setup@v6 # reads version from packageManager field
       - uses: actions/setup-node@v6
         with:
           node-version: 26
@@ -33,7 +33,7 @@ jobs:
       DATABASE_URL: file:./data/sqlite.db
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 26
@@ -48,7 +48,7 @@ jobs:
       DATABASE_URL: file:./data/sqlite.db
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 26
@@ -63,7 +63,7 @@ jobs:
       DATABASE_URL: file:./data/sqlite.db
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 26

--- a/docs/_branching-model.md
+++ b/docs/_branching-model.md
@@ -52,11 +52,12 @@ workflows, so the required CI checks would sit as "expected" forever and block t
 merge. The token is scoped to this repo with **Contents: read** and **Pull requests:
 read & write**.
 
-> **Do not enable "Automatically delete head branches".** The back-merge PR's head
-> is `main` itself — with auto-delete on, merging it deletes `main`. The repo keeps
-> `delete_branch_on_merge` **off** for this reason; feature branches are removed
-> explicitly via `gh pr merge --delete-branch` instead. The branch-protection ruleset
-> (#143) should also **restrict deletions** on `main` and `dev` as defense-in-depth.
+> **The back-merge PR's head is `main` itself**, so "Automatically delete head
+> branches" would delete `main` on merge (it did once, and `main` was restored). This
+> is prevented by a repository ruleset that **restricts deletions** on `main` and
+> `dev`: auto-delete skips protected branches, so feature branches are still cleaned up
+> automatically while `main`/`dev` survive. #143 folds this deletion rule into the
+> fuller branch-protection ruleset.
 
 ## Hotfix procedure
 

--- a/docs/_branching-model.md
+++ b/docs/_branching-model.md
@@ -52,6 +52,12 @@ workflows, so the required CI checks would sit as "expected" forever and block t
 merge. The token is scoped to this repo with **Contents: read** and **Pull requests:
 read & write**.
 
+> **Do not enable "Automatically delete head branches".** The back-merge PR's head
+> is `main` itself — with auto-delete on, merging it deletes `main`. The repo keeps
+> `delete_branch_on_merge` **off** for this reason; feature branches are removed
+> explicitly via `gh pr merge --delete-branch` instead. The branch-protection ruleset
+> (#143) should also **restrict deletions** on `main` and `dev` as defense-in-depth.
+
 ## Hotfix procedure
 
 1. Branch off `main` (e.g. `fix/123-...`).


### PR DESCRIPTION
Two follow-ups surfaced by the first release deploy (#166).

## 1. `pnpm/action-setup@v4` → `@v6`

The `v4` tag's action runtime is Node 20, now deprecated — GitHub forces it onto Node 24 and prints a warning on every CI job:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: pnpm/action-setup@v4.

`v6` ships a `node24` runtime (warning gone) and its `version` input stays optional, so the pnpm version still comes from the `packageManager` field — the #138 "don't hardcode pnpm version" constraint holds. (Our `node-version: 26` for the app was never the issue; this is the action's own runtime.)

## 2. Protect `main`/`dev` from deletion (back-merge pitfall)

During the first release, merging the automated back-merge PR (`main → dev`) **deleted `main`**, because the repo had "Automatically delete head branches" on and the back-merge PR's head is `main` itself. `main` was restored immediately.

Fix (targeted, keeps feature-branch cleanup):

- Created a repository **ruleset** ("Protect main and dev from deletion") that restricts `deletion` on `refs/heads/main` + `refs/heads/dev`. Auto-delete skips protected branches, so `main`/`dev` survive while feature branches are still auto-deleted.
- `delete_branch_on_merge` stays **on**.
- Documented in `docs/_branching-model.md`; #143 will fold this deletion rule into the fuller branch-protection ruleset.

> Note: the first commit message mentions turning `delete_branch_on_merge` off — that was the initial blunt fix, since replaced by the ruleset approach above (auto-delete re-enabled).

Refs #155, #138, #143