### PR TITLE
ci: post-deploy smoke test against production /health (#142)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,3 +28,13 @@ jobs:
       - run: flyctl deploy --remote-only --wait-timeout 5m
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      - name: Smoke test production /health
+        run: |
+          curl --fail --silent --show-error \
+            --retry 5 --retry-all-errors --retry-delay 5 \
+            https://vednemesicnik.cz/health
+      - name: Show app status
+        if: always()
+        run: flyctl status --app cz-vednemesicnik
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## What

Adds an end-to-end smoke test to the `deploy` job (`.github/workflows/deploy.yml`), appended after `flyctl deploy`:

- **Smoke test** — `curl`s the public `https://vednemesicnik.cz/health` endpoint. Unlike the machine health check that `flyctl deploy` waits for, this probes production from *outside* the Fly edge (TLS, routing, app boot). If it fails after retries, the workflow turns red → GitHub notification.
- **Show app status** — diagnostic `flyctl status`, gated `if: always()` so it also prints on failure.

## Why

`flyctl deploy` only waits for the internal machine health check. A final external probe confirms the site actually serves traffic through the public edge.

## Notes

- `--retry-all-errors` is required so `curl` retries connection-refused / HTTP 5xx (plain `--retry` does not).
- Reuses the existing `FLY_API_TOKEN` from the `production` environment.
- Verified locally: the exact `curl` invocation against live prod returns `OK` (200).

Closes #142.