### PR TITLE
ci: Docker build check for the Fly image (path-filtered) (#139)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,30 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm prisma:generate
       - run: pnpm app:build
+
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: changes
+        with:
+          filters: |
+            docker:
+              - 'docker/**'
+              - 'scripts/docker-entry-point*'
+              - '.dockerignore'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'prisma/**'
+      - uses: docker/setup-buildx-action@v4
+        if: steps.changes.outputs.docker == 'true'
+      - uses: docker/build-push-action@v7
+        if: steps.changes.outputs.docker == 'true'
+        with:
+          context: .
+          file: docker/fly/Dockerfile
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,11 @@ jobs:
 
   docker-build:
     runs-on: ubuntu-latest
+    # dorny/paths-filter reads the PR's changed files via the API on
+    # pull_request events; the top-level contents:read alone is not enough.
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4


### PR DESCRIPTION
## What

Adds a `docker-build` job to `.github/workflows/ci.yml` that builds `docker/fly/Dockerfile` on PRs.

- A `dorny/paths-filter` step **inside** the job gates the actual build on changes to Docker-relevant paths (`docker/**`, `scripts/docker-entry-point*`, `.dockerignore`, `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `prisma/**`). On unrelated PRs the job passes in seconds.
- Build only (`push: false`), no registry login, no secrets. GHA layer cache (`type=gha`).

## Why

Production deploys build the image remotely (`flyctl deploy --remote-only`), so a broken Dockerfile currently surfaces only at deploy time — after merge. This check catches it on the PR.

## Notes

- The filter lives inside an always-running job (not `on.paths`), so the future required check (#143) never gets stuck as "expected" on PRs that don't touch Docker files.
- `docker/setup-buildx-action` precedes `build-push-action` so the `type=gha` cache works.
- Actions pinned to their current latest majors (`paths-filter@v4`, `setup-buildx-action@v4`, `build-push-action@v7`) — the issue spec's v3/v3/v6 were stale; this matches the repo's "latest major" pinning style.
- On this PR (touches only `ci.yml`), `docker-build` is expected to skip the build and pass fast — demonstrating the path filter.

Closes #139.