### PR TITLE
ci: Storybook build check (#140)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,3 +103,18 @@ jobs:
           push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  storybook:
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: file:./data/sqlite.db
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm prisma:generate
+      - run: pnpm build-storybook


### PR DESCRIPTION
## What

Adds a `storybook` job to `.github/workflows/ci.yml` that runs `pnpm build-storybook` on every PR.

## Why

Storybook uses its own Vite config (`.storybook/vite.config.ts`), so `app:typecheck` / `app:build` don't catch stories that fail to compile. This job does — a story with a broken import fails the check.

## Notes

- Mirrors the other CI jobs: `pnpm/action-setup@v6`, `actions/setup-node@v6` with Node 26, `DATABASE_URL`, and `pnpm prisma:generate` before the build (stories import app code that depends on `@generated/*`). The issue's original v4/Node-24 snippet predates the Node 26 upgrade (#160).
- Compile check only — no artifact upload (`storybook-static` is gitignored).
- Verified locally: `pnpm build-storybook` completes successfully.

## Follow-up

Once merged and the `storybook` check has reported green, it gets added to the `branch-protection` ruleset's required checks (the follow-up noted in #143).

Closes #140.