### PR TITLE
ci: add Dependabot (monthly npm grouped + GitHub Actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+    labels:
+      - dependencies
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    labels:
+      - dependencies


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` with monthly version-update PRs for two ecosystems:

- **npm** (pnpm lockfile) — minor + patch grouped into one PR (`minor-and-patch`); majors stay individual for careful review.
- **github-actions** — the pinned actions in `ci.yml`, `deploy.yml`, `sync-dev.yml`.

Both labeled `dependencies` (existing label), opened against the default branch `dev`, where they run the full six-check CI suite and the branch-protection ruleset.

## Why monthly (not weekly)

For a solo maintainer, weekly bumps are noisy. `schedule.interval` only governs **version updates** — **security updates** still arrive immediately via GitHub advisories, independent of the interval. So monthly cuts routine noise without delaying security fixes.

## Notes

- `package-ecosystem: npm` is the correct ecosystem for pnpm (Dependabot reads `pnpm-lock.yaml`).
- Review incoming PRs per `.agents/rules/package-versions/RULE.md` (exact versions).

Closes #144.