### PR TITLE
release: CI/CD pipeline checks (smoke test, Docker, Storybook, Dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: monthly
+    labels:
+      - dependencies
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    labels:
+      - dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4 # reads version from packageManager field
+      - uses: pnpm/action-setup@v6 # reads version from packageManager field
       - uses: actions/setup-node@v6
         with:
           node-version: 26
@@ -33,7 +33,7 @@ jobs:
       DATABASE_URL: file:./data/sqlite.db
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 26
@@ -48,7 +48,7 @@ jobs:
       DATABASE_URL: file:./data/sqlite.db
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 26
@@ -63,7 +63,7 @@ jobs:
       DATABASE_URL: file:./data/sqlite.db
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version: 26

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,3 +103,18 @@ jobs:
           push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  storybook:
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: file:./data/sqlite.db
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm prisma:generate
+      - run: pnpm build-storybook

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,35 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm prisma:generate
       - run: pnpm app:build
+
+  docker-build:
+    runs-on: ubuntu-latest
+    # dorny/paths-filter reads the PR's changed files via the API on
+    # pull_request events; the top-level contents:read alone is not enough.
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: changes
+        with:
+          filters: |
+            docker:
+              - 'docker/**'
+              - 'scripts/docker-entry-point*'
+              - '.dockerignore'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'prisma/**'
+      - uses: docker/setup-buildx-action@v4
+        if: steps.changes.outputs.docker == 'true'
+      - uses: docker/build-push-action@v7
+        if: steps.changes.outputs.docker == 'true'
+        with:
+          context: .
+          file: docker/fly/Dockerfile
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,3 +28,13 @@ jobs:
       - run: flyctl deploy --remote-only --wait-timeout 5m
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      - name: Smoke test production /health
+        run: |
+          curl --fail --silent --show-error \
+            --retry 5 --retry-all-errors --retry-delay 5 \
+            https://vednemesicnik.cz/health
+      - name: Show app status
+        if: always()
+        run: flyctl status --app cz-vednemesicnik
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/docs/_branching-model.md
+++ b/docs/_branching-model.md
@@ -52,6 +52,13 @@ workflows, so the required CI checks would sit as "expected" forever and block t
 merge. The token is scoped to this repo with **Contents: read** and **Pull requests:
 read & write**.
 
+> **The back-merge PR's head is `main` itself**, so "Automatically delete head
+> branches" would delete `main` on merge (it did once, and `main` was restored). This
+> is prevented by a repository ruleset that **restricts deletions** on `main` and
+> `dev`: auto-delete skips protected branches, so feature branches are still cleaned up
+> automatically while `main`/`dev` survive. #143 folds this deletion rule into the
+> fuller branch-protection ruleset.
+
 ## Hotfix procedure
 
 1. Branch off `main` (e.g. `fix/123-...`).


### PR DESCRIPTION
## Release `dev → main`

Ships the remaining CI/CD pipeline work to production. Merging this (as a **merge commit** — never squash) triggers the first full auto-deploy: CI-gated `flyctl deploy` + post-deploy smoke test against production `/health`.

### Included
- **#142** — post-deploy smoke test against production `/health` (`deploy.yml`)
- **#139** — Docker build check for the Fly image, path-filtered (`ci.yml`)
- **#140** — Storybook build check (`ci.yml`)
- **#144** — Dependabot: monthly npm (grouped) + GitHub Actions (`dependabot.yml`)
- **#168** — pnpm/action-setup bump to v6 + back-merge pitfall doc

### Already on `main` (from release #166)
- #138 core CI, #141 auto-deploy to Fly

### After merge
- `deploy.yml` runs on the push to `main`: CI re-validates, then deploys to Fly and smoke-tests prod `/health`.
- `sync-dev.yml` opens an automated back-merge PR `main → dev` — merge it (merge commit) to reconverge.

⚠️ **Merge method: merge commit** (per `docs/_branching-model.md` — squashing a release would permanently diverge `dev` and `main`).