### PR TITLE
fix(ci): grant checks job pull-requests:read for reusable ci.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,12 @@ concurrency:
 
 jobs:
   checks:
+    # ci.yml's docker-build job runs dorny/paths-filter, which needs
+    # pull-requests:read. A reusable workflow can only use permissions the
+    # caller grants, so it must be declared here on the calling job.
+    permissions:
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/ci.yml
 
   deploy:


### PR DESCRIPTION
## Problem

The first real auto-deploy (release #174) failed at **startup** (`startup_failure`, before any job ran) — so **no deploy happened and production was untouched**.

Root cause: `deploy.yml` runs CI via `uses: ./.github/workflows/ci.yml` (workflow_call). `ci.yml`'s `docker-build` job requests `pull-requests: read` (for `dorny/paths-filter`, added in #139). A **reusable workflow can only use permissions the caller grants**, but the `checks` job only had the top-level `contents: read`. Once `docker-build` reached `main` via the release, the mismatch made the whole Deploy workflow fail to start.

This didn't surface on PR CI because there `ci.yml` runs directly on `pull_request` (not called), so its job permissions apply normally.

## Fix

Grant `pull-requests: read` on the `checks` job specifically (the one that calls `ci.yml`). The `deploy` job stays at `contents: read` — least privilege.

## Validation

Merges to `dev`, then a release `dev → main` will trigger the Deploy workflow, which should now start, run CI, deploy to Fly, and pass the `/health` smoke test.