### PR TITLE
release: fix deploy workflow_call permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,12 @@ concurrency:
 
 jobs:
   checks:
+    # ci.yml's docker-build job runs dorny/paths-filter, which needs
+    # pull-requests:read. A reusable workflow can only use permissions the
+    # caller grants, so it must be declared here on the calling job.
+    permissions:
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/ci.yml
 
   deploy:


### PR DESCRIPTION
## Release `dev → main`

Ships the deploy-workflow permissions fix (#176) so the auto-deploy actually runs.

The first attempt (release #174) failed at startup because the reusable `ci.yml` requested `pull-requests: read` that the `checks` job hadn't been granted. #176 grants it on the `checks` job (deploy job stays `contents: read`).

Merging this (**merge commit**) triggers the Deploy workflow, which should now start, run CI, deploy to Fly, and pass the `/health` smoke test.

⚠️ **Merge method: merge commit** (per `docs/_branching-model.md`).