### PR TITLE
fix(ci): smoke-test the Fly origin, not the Cloudflare-fronted domain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,11 +34,14 @@ jobs:
       - run: flyctl deploy --remote-only --wait-timeout 5m
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-      - name: Smoke test production /health
+      # Probe the Fly origin directly, not the public vednemesicnik.cz domain:
+      # Cloudflare fronts the public domain and blocks CI runner IPs with 403.
+      # The origin confirms the deployed app booted and serves over TLS.
+      - name: Smoke test Fly origin /health
         run: |
           curl --fail --silent --show-error \
             --retry 5 --retry-all-errors --retry-delay 5 \
-            https://vednemesicnik.cz/health
+            https://cz-vednemesicnik.fly.dev/health
       - name: Show app status
         if: always()
         run: flyctl status --app cz-vednemesicnik


### PR DESCRIPTION
## Problem

The post-deploy smoke test hit `https://vednemesicnik.cz/health`, but that domain is fronted by **Cloudflare**, which blocks GitHub Actions runner IPs with **403** — so the deploy job went red even though `flyctl deploy` succeeded and production is healthy.

## Fix

Probe the **Fly origin** `https://cz-vednemesicnik.fly.dev/health` instead — it bypasses Cloudflare and confirms the deployed app booted and serves over TLS. The Cloudflare edge is configured independently of app deploys.

## Verified

`curl https://cz-vednemesicnik.fly.dev/health` → 200 (from a datacenter-like path); the public domain returns 403 to CI IPs but 200 to normal clients.

Follow-up to the deploy pipeline brought live in release #177.