### PR TITLE
feat(security): report-only nonce-based Content-Security-Policy (#131)

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -6,6 +6,7 @@
  * For more information, see https://remix.run/file-conventions/entry.server
  */
 
+import { randomBytes } from 'node:crypto'
 import { PassThrough } from 'node:stream'
 
 import { createReadableStreamFromReadable } from '@react-router/node'
@@ -25,6 +26,26 @@ export const streamTimeout = 5000
 initEnv()
 global.ENV = getEnv()
 
+// Single source of the full Content-Security-Policy, parameterised by the
+// per-request nonce that authorises React Router's inline hydration script.
+// `style-src 'unsafe-inline'` is a pragmatic start for React inline style
+// attributes; rsms.me serves the Inter font stylesheet and its woff2 files.
+function buildContentSecurityPolicy(nonce: string): string {
+  return [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}'`,
+    "style-src 'self' 'unsafe-inline' https://rsms.me",
+    "img-src 'self' data: blob:",
+    "media-src 'self'",
+    "connect-src 'self'",
+    "font-src 'self' https://rsms.me",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+  ].join('; ')
+}
+
 export default function handleRequest(
   request: Request,
   responseStatusCode: number,
@@ -35,13 +56,21 @@ export default function handleRequest(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _loadContext: RouterContextProvider,
 ) {
+  // Per-request nonce authorising React Router's inline hydration script.
+  const nonce = randomBytes(16).toString('base64')
+
   // Baseline security headers, set once so both the bot and browser paths
   // inherit them.
   responseHeaders.set('X-Content-Type-Options', 'nosniff')
   responseHeaders.set('X-Frame-Options', 'DENY')
-  // frame-ancestors covers browsers that ignore X-Frame-Options; the CSP
-  // sub-issue of #126 will extend this header value with a full policy later.
+  // frame-ancestors covers browsers that ignore X-Frame-Options. The full
+  // nonce-based policy ships as report-only first (#131 step 1); a follow-up
+  // PR promotes it to the enforced header.
   responseHeaders.set('Content-Security-Policy', "frame-ancestors 'none'")
+  responseHeaders.set(
+    'Content-Security-Policy-Report-Only',
+    buildContentSecurityPolicy(nonce),
+  )
 
   // Route loaders may set a stricter policy (magic-link verify sends
   // `no-referrer`) — only fill in the default when none is set.
@@ -63,12 +92,14 @@ export default function handleRequest(
         responseStatusCode,
         responseHeaders,
         reactRouterContext,
+        nonce,
       )
     : handleBrowserRequest(
         request,
         responseStatusCode,
         responseHeaders,
         reactRouterContext,
+        nonce,
       )
 }
 
@@ -77,12 +108,18 @@ function handleBotRequest(
   responseStatusCode: number,
   responseHeaders: Headers,
   reactRouterContext: EntryContext,
+  nonce: string,
 ) {
   return new Promise((resolve, reject) => {
     let shellRendered = false
     const { pipe, abort } = renderToPipeableStream(
-      <ServerRouter context={reactRouterContext} url={request.url} />,
+      <ServerRouter
+        context={reactRouterContext}
+        nonce={nonce}
+        url={request.url}
+      />,
       {
+        nonce,
         onAllReady() {
           shellRendered = true
           const body = new PassThrough()
@@ -125,12 +162,18 @@ function handleBrowserRequest(
   responseStatusCode: number,
   responseHeaders: Headers,
   reactRouterContext: EntryContext,
+  nonce: string,
 ) {
   return new Promise((resolve, reject) => {
     let shellRendered = false
     const { pipe, abort } = renderToPipeableStream(
-      <ServerRouter context={reactRouterContext} url={request.url} />,
+      <ServerRouter
+        context={reactRouterContext}
+        nonce={nonce}
+        url={request.url}
+      />,
       {
+        nonce,
         onError(error: unknown) {
           responseStatusCode = 500
           // Log streaming rendering errors from inside the shell.  Don't log


### PR DESCRIPTION
Part of #126. Implements **step 1** of #131 (nonce-based Content-Security-Policy).

## What

Extends the baseline security headers (#127) toward a full nonce-based CSP,
shipped **report-only first** so the live site can't break while the policy is
tuned.

- Generate a per-request nonce (`randomBytes(16).toString('base64')`) in
  `app/entry.server.tsx`.
- Thread it into both render paths via `<ServerRouter nonce>` and the
  `renderToPipeableStream(..., { nonce })` option — the documented React Router
  v8 pattern. The nonce propagates through React context, so `<Scripts>` /
  `<ScrollRestoration>` in `root.tsx` inherit it automatically (no `root.tsx`
  change needed).
- Emit the full app-tuned policy as `Content-Security-Policy-Report-Only`, while
  the enforced `Content-Security-Policy: frame-ancestors 'none'` baseline stays
  in place.

## Policy

```
default-src 'self'; script-src 'self' 'nonce-<per-request>';
style-src 'self' 'unsafe-inline' https://rsms.me; img-src 'self' data: blob:;
media-src 'self'; connect-src 'self'; font-src 'self' https://rsms.me;
object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'
```

`https://rsms.me` is the only external origin (Inter font stylesheet + woff2).
`style-src 'unsafe-inline'` is a pragmatic start for React inline style
attributes.

## Verified

- `pnpm app:typecheck` and `pnpm test` (137 tests) pass.
- `curl -sI /` shows enforced `frame-ancestors 'none'` plus the report-only full
  policy; the `script-src` nonce is fresh per request.
- Page HTML: every framework-emitted inline script carries the matching nonce;
  the only nonce-less script is `<script src="/resources/env.js">` (external
  `src`, allowed by `script-src 'self'`).

## Remaining manual verification (before the step-2 enforce PR)

Click through the whole app with DevTools console open and fix any
`[Report Only]` violations — public site, administration, all five sign-in
methods (magic link, Google OAuth, passkey, password with
`ALLOW_PASSWORD_SIGN_IN=true`, TOTP), image uploads, PDF archive. This needs a
seeded/credentialed session and wasn't runnable in the implementation
environment.

## Follow-up (separate PR)

Step 2: promote the tuned policy to the enforced `Content-Security-Policy`
header (it already includes `frame-ancestors 'none'`) and drop the report-only
header.
