### PR TITLE
Revert nonce-based CSP (#182 / step 1 of #131)

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -6,7 +6,6 @@
  * For more information, see https://remix.run/file-conventions/entry.server
  */
 
-import { randomBytes } from 'node:crypto'
 import { PassThrough } from 'node:stream'
 
 import { createReadableStreamFromReadable } from '@react-router/node'
@@ -26,26 +25,6 @@ export const streamTimeout = 5000
 initEnv()
 global.ENV = getEnv()
 
-// Single source of the full Content-Security-Policy, parameterised by the
-// per-request nonce that authorises React Router's inline hydration script.
-// `style-src 'unsafe-inline'` is a pragmatic start for React inline style
-// attributes; rsms.me serves the Inter font stylesheet and its woff2 files.
-function buildContentSecurityPolicy(nonce: string): string {
-  return [
-    "default-src 'self'",
-    `script-src 'self' 'nonce-${nonce}'`,
-    "style-src 'self' 'unsafe-inline' https://rsms.me",
-    "img-src 'self' data: blob:",
-    "media-src 'self'",
-    "connect-src 'self'",
-    "font-src 'self' https://rsms.me",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'none'",
-  ].join('; ')
-}
-
 export default function handleRequest(
   request: Request,
   responseStatusCode: number,
@@ -56,21 +35,13 @@ export default function handleRequest(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _loadContext: RouterContextProvider,
 ) {
-  // Per-request nonce authorising React Router's inline hydration script.
-  const nonce = randomBytes(16).toString('base64')
-
   // Baseline security headers, set once so both the bot and browser paths
   // inherit them.
   responseHeaders.set('X-Content-Type-Options', 'nosniff')
   responseHeaders.set('X-Frame-Options', 'DENY')
-  // frame-ancestors covers browsers that ignore X-Frame-Options. The full
-  // nonce-based policy ships as report-only first (#131 step 1); a follow-up
-  // PR promotes it to the enforced header.
+  // frame-ancestors covers browsers that ignore X-Frame-Options; the CSP
+  // sub-issue of #126 will extend this header value with a full policy later.
   responseHeaders.set('Content-Security-Policy', "frame-ancestors 'none'")
-  responseHeaders.set(
-    'Content-Security-Policy-Report-Only',
-    buildContentSecurityPolicy(nonce),
-  )
 
   // Route loaders may set a stricter policy (magic-link verify sends
   // `no-referrer`) — only fill in the default when none is set.
@@ -92,14 +63,12 @@ export default function handleRequest(
         responseStatusCode,
         responseHeaders,
         reactRouterContext,
-        nonce,
       )
     : handleBrowserRequest(
         request,
         responseStatusCode,
         responseHeaders,
         reactRouterContext,
-        nonce,
       )
 }
 
@@ -108,18 +77,12 @@ function handleBotRequest(
   responseStatusCode: number,
   responseHeaders: Headers,
   reactRouterContext: EntryContext,
-  nonce: string,
 ) {
   return new Promise((resolve, reject) => {
     let shellRendered = false
     const { pipe, abort } = renderToPipeableStream(
-      <ServerRouter
-        context={reactRouterContext}
-        nonce={nonce}
-        url={request.url}
-      />,
+      <ServerRouter context={reactRouterContext} url={request.url} />,
       {
-        nonce,
         onAllReady() {
           shellRendered = true
           const body = new PassThrough()
@@ -162,18 +125,12 @@ function handleBrowserRequest(
   responseStatusCode: number,
   responseHeaders: Headers,
   reactRouterContext: EntryContext,
-  nonce: string,
 ) {
   return new Promise((resolve, reject) => {
     let shellRendered = false
     const { pipe, abort } = renderToPipeableStream(
-      <ServerRouter
-        context={reactRouterContext}
-        nonce={nonce}
-        url={request.url}
-      />,
+      <ServerRouter context={reactRouterContext} url={request.url} />,
       {
-        nonce,
         onError(error: unknown) {
           responseStatusCode = 500
           // Log streaming rendering errors from inside the shell.  Don't log


### PR DESCRIPTION
Reverts #182 (step 1 of #131), restoring `app/entry.server.tsx` to the #127 baseline (`Content-Security-Policy: frame-ancestors 'none'` only).

## Why

A browser walkthrough of #182 (report-only nonce-based CSP) surfaced a hard React Router 8.2 limitation that makes a clean nonce-based CSP impractical right now:

- `<ServerRouter nonce>` feeds a single `FrameworkContext.nonce` consumed by `<Links>`, `<Scripts>`, **and** the single-fetch streaming data scripts. Noncing `<Links>` triggers a **React hydration mismatch on every page** — React can't hydrate a nonced non-script element (the browser blanks the `nonce` attribute to `""`), a [documented React behavior](https://github.com/sebmck/react-nonce-hydration-bug).
- Removing the `<link>` nonce (via a `NonceProvider`) fixes hydration but leaves the streaming scripts (`window.__reactRouterContext.streamController.*`) **un-nonced**, which enforced CSP would block. Those scripts also drop the nonce in production even via `ServerRouter` — [react-router#15083](https://github.com/remix-run/react-router/issues/15083).

On RR 8.2.0 you can have clean hydration **or** nonced framework/streaming scripts, not both, without reaching into unstable internal APIs — and even that may not survive production. Rather than ship report-only noise plus a live hydration regression on `dev`, we revert and refile the nonce-based CSP as a future enhancement (see #185).

The baseline `frame-ancestors 'none'`, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, and HSTS headers from #127 are unaffected.

## Verified

- `pnpm app:typecheck` passes.
- `app/entry.server.tsx` matches the #127 baseline; `curl -sI /` returns only `Content-Security-Policy: frame-ancestors 'none'` (no report-only header, no nonce plumbing).
