### PR TITLE
feat(security): add authentication audit log (AuthEvent) (#132)

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -7,7 +7,6 @@
  */
 
 import { PassThrough } from 'node:stream'
-import { remember } from '@epic-web/remember'
 import { createReadableStreamFromReadable } from '@react-router/node'
 import { isbot } from 'isbot'
 import { renderToPipeableStream } from 'react-dom/server'
@@ -17,7 +16,7 @@ import {
   ServerRouter,
 } from 'react-router'
 
-import { cleanupOldAuthEvents } from '~/utils/auth-event.server'
+import { startAuthEventRetention } from '~/utils/auth-event.server'
 import { getEnv, initEnv } from '~/utils/env.server'
 
 // Reject/cancel all pending promises after 5 seconds
@@ -26,16 +25,8 @@ export const streamTimeout = 5000
 initEnv()
 global.ENV = getEnv()
 
-// Auth-event retention: prune events past the 90-day window. No cron mechanism
-// exists, so run once at startup and once a day thereafter. min_machines_running
-// keeps a process alive, so the interval fires reliably; .unref() lets the
-// process exit without waiting on it. Fire-and-forget. remember() guards against
-// re-registration when this module is re-evaluated (e.g. dev HMR) so exactly one
-// interval exists per process.
-remember('authEventRetention', () => {
-  cleanupOldAuthEvents()
-  return setInterval(cleanupOldAuthEvents, 24 * 60 * 60 * 1000).unref()
-})
+// Prune auth events past the retention window, once at startup and daily after.
+startAuthEventRetention()
 
 export default function handleRequest(
   request: Request,

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -17,6 +17,7 @@ import {
   ServerRouter,
 } from 'react-router'
 
+import { cleanupOldAuthEvents } from '~/utils/auth-event.server'
 import { getEnv, initEnv } from '~/utils/env.server'
 
 // Reject/cancel all pending promises after 5 seconds
@@ -24,6 +25,13 @@ export const streamTimeout = 5000
 
 initEnv()
 global.ENV = getEnv()
+
+// Auth-event retention: prune events past the 90-day window. No cron mechanism
+// exists, so run once at startup and once a day thereafter. min_machines_running
+// keeps a process alive, so the interval fires reliably; .unref() lets the
+// process exit without waiting on it. Fire-and-forget.
+cleanupOldAuthEvents()
+setInterval(cleanupOldAuthEvents, 24 * 60 * 60 * 1000).unref()
 
 export default function handleRequest(
   request: Request,

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -7,7 +7,7 @@
  */
 
 import { PassThrough } from 'node:stream'
-
+import { remember } from '@epic-web/remember'
 import { createReadableStreamFromReadable } from '@react-router/node'
 import { isbot } from 'isbot'
 import { renderToPipeableStream } from 'react-dom/server'
@@ -29,9 +29,13 @@ global.ENV = getEnv()
 // Auth-event retention: prune events past the 90-day window. No cron mechanism
 // exists, so run once at startup and once a day thereafter. min_machines_running
 // keeps a process alive, so the interval fires reliably; .unref() lets the
-// process exit without waiting on it. Fire-and-forget.
-cleanupOldAuthEvents()
-setInterval(cleanupOldAuthEvents, 24 * 60 * 60 * 1000).unref()
+// process exit without waiting on it. Fire-and-forget. remember() guards against
+// re-registration when this module is re-evaluated (e.g. dev HMR) so exactly one
+// interval exists per process.
+remember('authEventRetention', () => {
+  cleanupOldAuthEvents()
+  return setInterval(cleanupOldAuthEvents, 24 * 60 * 60 * 1000).unref()
+})
 
 export default function handleRequest(
   request: Request,

--- a/app/routes/administration/sign-in/google/callback/_loader.ts
+++ b/app/routes/administration/sign-in/google/callback/_loader.ts
@@ -33,7 +33,17 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
   // Preserve the original redirectTo across the error bounce, so retrying sign-in
   // still returns the user to where they started. (It was sanitized on the way
   // in; the sign-in loader re-validates it via safeRedirect.)
-  const failTo = (error: 'oauth' | 'domain' | 'account') => {
+  // Every failure path funnels through here, so record the audit row once in one
+  // place. `email` is only known past the domain check; earlier OAuth-stage
+  // failures (denied consent, bad state/nonce, token exchange) log without it.
+  const failTo = (error: 'oauth' | 'domain' | 'account', email?: string) => {
+    recordAuthEvent({
+      email,
+      event: 'sign_in_failure',
+      method: 'google',
+      request,
+    })
+
     const search = new URLSearchParams({ error })
     if (redirectTo) search.set('redirectTo', redirectTo)
 
@@ -101,13 +111,7 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
     email === undefined ||
     !email.endsWith(`@${ALLOWED_EMAIL_DOMAIN}`)
   ) {
-    recordAuthEvent({
-      email,
-      event: 'sign_in_failure',
-      method: 'google',
-      request,
-    })
-    throw failTo('domain')
+    throw failTo('domain', email)
   }
 
   try {
@@ -136,13 +140,7 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
     const user = await findExistingUserByEmail(email)
 
     if (user === null) {
-      recordAuthEvent({
-        email,
-        event: 'sign_in_failure',
-        method: 'google',
-        request,
-      })
-      throw failTo('account')
+      throw failTo('account', email)
     }
 
     await prisma.connection.create({

--- a/app/routes/administration/sign-in/google/callback/_loader.ts
+++ b/app/routes/administration/sign-in/google/callback/_loader.ts
@@ -1,8 +1,8 @@
 import { ALLOWED_EMAIL_DOMAIN } from '@constants/auth'
 import type { TokenPayload } from 'google-auth-library'
 import { redirect } from 'react-router'
-
 import { requireUnauthenticated } from '~/utils/auth.server'
+import { recordAuthEvent } from '~/utils/auth-event.server'
 import { prisma } from '~/utils/db.server'
 import {
   createGoogleOAuthClient,
@@ -101,6 +101,12 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
     email === undefined ||
     !email.endsWith(`@${ALLOWED_EMAIL_DOMAIN}`)
   ) {
+    recordAuthEvent({
+      email,
+      event: 'sign_in_failure',
+      method: 'google',
+      request,
+    })
     throw failTo('domain')
   }
 
@@ -120,6 +126,7 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
       return await signInUser(
         request,
         connection.userId,
+        'google',
         redirectTo,
         new Headers({ 'Set-Cookie': destroyCookie }),
       )
@@ -128,7 +135,15 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
     // First OAuth sign-in for an existing account → auto-link via verified email.
     const user = await findExistingUserByEmail(email)
 
-    if (user === null) throw failTo('account')
+    if (user === null) {
+      recordAuthEvent({
+        email,
+        event: 'sign_in_failure',
+        method: 'google',
+        request,
+      })
+      throw failTo('account')
+    }
 
     await prisma.connection.create({
       data: {
@@ -141,6 +156,7 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
     return await signInUser(
       request,
       user.id,
+      'google',
       redirectTo,
       new Headers({ 'Set-Cookie': destroyCookie }),
     )

--- a/app/routes/administration/sign-in/magic-link/verify/_action.ts
+++ b/app/routes/administration/sign-in/magic-link/verify/_action.ts
@@ -1,6 +1,6 @@
 import { redirect } from 'react-router'
-
 import { requireUnauthenticated } from '~/utils/auth.server'
+import { recordAuthEvent } from '~/utils/auth-event.server'
 import { checkHoneypot } from '~/utils/honeypot.server'
 import { consumeMagicLinkToken } from '~/utils/magic-link.server'
 import { findExistingUserByEmail, signInUser } from '~/utils/sign-in.server'
@@ -29,6 +29,12 @@ export const action = async ({ request }: Route.ActionArgs) => {
   const isValid = await consumeMagicLinkToken(normalizedEmail, token)
 
   if (!isValid) {
+    recordAuthEvent({
+      email: normalizedEmail,
+      event: 'sign_in_failure',
+      method: 'magic_link',
+      request,
+    })
     throw redirect('/administration/sign-in/magic-link', { status: 303 })
   }
 
@@ -36,9 +42,15 @@ export const action = async ({ request }: Route.ActionArgs) => {
 
   // The account may have been removed between request and click.
   if (user === null) {
+    recordAuthEvent({
+      email: normalizedEmail,
+      event: 'sign_in_failure',
+      method: 'magic_link',
+      request,
+    })
     throw redirect('/administration/sign-in', { status: 303 })
   }
 
   // Always throws: a redirect to /administration on success.
-  return await signInUser(request, user.id)
+  return await signInUser(request, user.id, 'magic_link')
 }

--- a/app/routes/administration/sign-in/passkey/verify-authentication-response/_action.ts
+++ b/app/routes/administration/sign-in/passkey/verify-authentication-response/_action.ts
@@ -34,19 +34,38 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     return data({ status: 'fail', verified: false }, { status: 400 })
   }
 
-  const verifiedAuthenticationResponse = await verifyAuthenticationResponse({
-    credential: {
-      counter: Number(passkey.credentialCounter),
-      id: passkey.credentialId,
-      publicKey: passkey.credentialPublicKey,
-      transports: JSON.parse(passkey.credentialTransports),
-    },
-    expectedChallenge: biometricChallenge ?? '',
-    expectedOrigin: process.env.RELYING_PARTY_ORIGIN ?? '',
-    expectedRPID: process.env.RELYING_PARTY_ID ?? '',
-    requireUserVerification: true,
-    response: body,
-  })
+  let verifiedAuthenticationResponse: Awaited<
+    ReturnType<typeof verifyAuthenticationResponse>
+  >
+  try {
+    verifiedAuthenticationResponse = await verifyAuthenticationResponse({
+      credential: {
+        counter: Number(passkey.credentialCounter),
+        id: passkey.credentialId,
+        publicKey: passkey.credentialPublicKey,
+        transports: JSON.parse(passkey.credentialTransports),
+      },
+      expectedChallenge: biometricChallenge ?? '',
+      expectedOrigin: process.env.RELYING_PARTY_ORIGIN ?? '',
+      expectedRPID: process.env.RELYING_PARTY_ID ?? '',
+      requireUserVerification: true,
+      response: body,
+    })
+  } catch (error) {
+    // A malformed client payload / unexpected WebAuthn response throws here;
+    // treat it as a failed attempt rather than a 500 so it is audited too.
+    console.error(
+      '[passkey] authentication response verification failed',
+      error,
+    )
+    recordAuthEvent({
+      event: 'sign_in_failure',
+      method: 'passkey',
+      request,
+      userId: passkey.userId,
+    })
+    return data({ status: 'fail', verified: false }, { status: 400 })
+  }
 
   if (!verifiedAuthenticationResponse.verified) {
     recordAuthEvent({

--- a/app/routes/administration/sign-in/passkey/verify-authentication-response/_action.ts
+++ b/app/routes/administration/sign-in/passkey/verify-authentication-response/_action.ts
@@ -1,6 +1,7 @@
 import { verifyAuthenticationResponse } from '@simplewebauthn/server'
 import { type ActionFunctionArgs, data } from 'react-router'
 
+import { recordAuthEvent } from '~/utils/auth-event.server'
 import {
   deleteBiometricCookieSession,
   getBiometricChallenge,
@@ -29,6 +30,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   })
 
   if (passkey === null) {
+    recordAuthEvent({ event: 'sign_in_failure', method: 'passkey', request })
     return data({ status: 'fail', verified: false }, { status: 400 })
   }
 
@@ -47,6 +49,12 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   })
 
   if (!verifiedAuthenticationResponse.verified) {
+    recordAuthEvent({
+      event: 'sign_in_failure',
+      method: 'passkey',
+      request,
+      userId: passkey.userId,
+    })
     return data({ status: 'fail', verified: false }, { status: 400 })
   }
 
@@ -65,5 +73,11 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     'Set-Cookie': await deleteBiometricCookieSession(biometricCookieSession),
   })
 
-  return await signInUser(request, passkey.userId, redirectTo, headers)
+  return await signInUser(
+    request,
+    passkey.userId,
+    'passkey',
+    redirectTo,
+    headers,
+  )
 }

--- a/app/routes/administration/sign-in/password/_action.ts
+++ b/app/routes/administration/sign-in/password/_action.ts
@@ -85,8 +85,13 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
   // failed attempt against a known account is worth correlating by userId.
   const existingUserId = user?.id
 
-  if (user !== null && user.password !== null) {
-    const isValid = await bcrypt.compare(password, user.password.hash)
+  if (user !== null) {
+    // An account without a password hash (e.g. OAuth/passkey-only) must not be
+    // signed in via this path: treat a missing hash as an invalid attempt
+    // instead of skipping the check and authenticating with any password.
+    const isValid =
+      user.password !== null &&
+      (await bcrypt.compare(password, user.password.hash))
 
     user = isValid ? user : null
   }

--- a/app/routes/administration/sign-in/password/_action.ts
+++ b/app/routes/administration/sign-in/password/_action.ts
@@ -81,6 +81,10 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
     where: { email },
   })
 
+  // Capture the id up front: `user` is nulled on a wrong password below, but a
+  // failed attempt against a known account is worth correlating by userId.
+  const existingUserId = user?.id
+
   if (user !== null && user.password !== null) {
     const isValid = await bcrypt.compare(password, user.password.hash)
 
@@ -93,6 +97,7 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
       event: 'sign_in_failure',
       method: 'password',
       request,
+      userId: existingUserId,
     })
     return data(
       {

--- a/app/routes/administration/sign-in/password/_action.ts
+++ b/app/routes/administration/sign-in/password/_action.ts
@@ -1,8 +1,8 @@
 import { parseWithZod } from '@conform-to/zod/v4'
 import bcrypt from 'bcryptjs'
 import { data, redirect } from 'react-router'
-
 import { setSessionAuthCookieSession } from '~/utils/auth.server'
+import { recordAuthEvent } from '~/utils/auth-event.server'
 import { prisma } from '~/utils/db.server'
 import { formatRetryAfter } from '~/utils/format-retry-after'
 import { checkHoneypot } from '~/utils/honeypot.server'
@@ -88,6 +88,12 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
   }
 
   if (user === null) {
+    recordAuthEvent({
+      email,
+      event: 'sign_in_failure',
+      method: 'password',
+      request,
+    })
     return data(
       {
         authenticationOptions: null,
@@ -119,6 +125,13 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
   }
 
   const session = await createSession(user.id)
+
+  recordAuthEvent({
+    event: 'sign_in_success',
+    method: 'password',
+    request,
+    userId: user.id,
+  })
 
   throw redirect('/administration', {
     headers: {

--- a/app/routes/administration/sign-in/verify-2fa/_action.ts
+++ b/app/routes/administration/sign-in/verify-2fa/_action.ts
@@ -1,7 +1,7 @@
 import { parseWithZod } from '@conform-to/zod/v4'
 import { data, redirect } from 'react-router'
-
 import { setSessionAuthCookieSession } from '~/utils/auth.server'
+import { recordAuthEvent } from '~/utils/auth-event.server'
 import { redeemBackupCode } from '~/utils/backup-codes.server'
 import { formatRetryAfter } from '~/utils/format-retry-after'
 import { checkHoneypot } from '~/utils/honeypot.server'
@@ -81,8 +81,12 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
   // Second factor verified — create the session and clear the pending cookie.
   // 303 See Other so the browser issues a GET after this POST, matching the
   // other redirects in this flow. Shared by the TOTP and backup-code branches.
-  const succeed = async (): Promise<never> => {
+  const succeed = async (
+    method: 'two_factor' | 'backup_code',
+  ): Promise<never> => {
     const session = await createSession(userId)
+
+    recordAuthEvent({ event: 'sign_in_success', method, request, userId })
 
     const headers = new Headers()
     headers.append(
@@ -105,6 +109,13 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
   // so the user must re-enter their password. Covers both TOTP and backup-code
   // attempts, bounding brute-forcing within the cookie lifetime.
   const fail = async (field: 'backupCode' | 'code', message: string) => {
+    recordAuthEvent({
+      event: 'two_factor_failure',
+      method: field === 'backupCode' ? 'backup_code' : 'two_factor',
+      request,
+      userId,
+    })
+
     const attempts = getPendingTwoFactorAttempts(cookieSession) + 1
 
     if (attempts >= MAX_TWO_FACTOR_ATTEMPTS) {
@@ -148,7 +159,7 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
       return fail('backupCode', 'Záložní kód je neplatný nebo již byl použit.')
     }
 
-    return succeed()
+    return succeed('backup_code')
   }
 
   // The schema guarantees one field is present, so a missing backup code means a
@@ -175,5 +186,5 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
     return fail('code', 'Kód je nesprávný nebo jeho platnost vypršela.')
   }
 
-  return succeed()
+  return succeed('two_factor')
 }

--- a/app/routes/administration/sign-out/_action.ts
+++ b/app/routes/administration/sign-out/_action.ts
@@ -1,10 +1,11 @@
 import type { ActionFunctionArgs } from 'react-router'
-
 import {
   deleteSessionAuthCookieSession,
   getSessionAuthCookieSession,
   getSessionAuthId,
 } from '~/utils/auth.server'
+import { recordAuthEvent } from '~/utils/auth-event.server'
+import { prisma } from '~/utils/db.server'
 import { redirectBack } from '~/utils/redirect-back'
 
 import { deleteSession } from './utils/delete-session.server'
@@ -12,6 +13,16 @@ import { deleteSession } from './utils/delete-session.server'
 export const action = async ({ request }: ActionFunctionArgs) => {
   const sessionAuthCookieSession = await getSessionAuthCookieSession(request)
   const sessionId = getSessionAuthId(sessionAuthCookieSession)
+
+  // Resolve the owner for the audit log before the session row is deleted.
+  const session = sessionId
+    ? await prisma.session.findUnique({
+        select: { userId: true },
+        where: { id: sessionId },
+      })
+    : null
+
+  recordAuthEvent({ event: 'sign_out', request, userId: session?.userId })
 
   deleteSession(sessionId)
 

--- a/app/routes/administration/sign-out/_action.ts
+++ b/app/routes/administration/sign-out/_action.ts
@@ -14,11 +14,13 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   const sessionAuthCookieSession = await getSessionAuthCookieSession(request)
   const sessionId = getSessionAuthId(sessionAuthCookieSession)
 
-  // Resolve the owner for the audit log before the session row is deleted.
-  // Best-effort like the logging itself: a transient DB fault must not break
-  // sign-out, so fall back to an unset userId instead of throwing.
-  let userId: string | undefined
+  // Only record / delete for an actual session — a session-less POST is not a
+  // real sign-out and must not create a noisy row or delete an undefined id.
   if (sessionId) {
+    // Resolve the owner for the audit log before the session row is deleted.
+    // Best-effort like the logging itself: a transient DB fault must not break
+    // sign-out, so fall back to an unset userId instead of throwing.
+    let userId: string | undefined
     try {
       const session = await prisma.session.findUnique({
         select: { userId: true },
@@ -28,11 +30,11 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     } catch (error) {
       console.error('Failed to resolve session owner for sign-out event', error)
     }
+
+    recordAuthEvent({ event: 'sign_out', request, userId })
+
+    deleteSession(sessionId)
   }
-
-  recordAuthEvent({ event: 'sign_out', request, userId })
-
-  deleteSession(sessionId)
 
   return redirectBack(request, {
     headers: {

--- a/app/routes/administration/sign-out/_action.ts
+++ b/app/routes/administration/sign-out/_action.ts
@@ -15,14 +15,22 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   const sessionId = getSessionAuthId(sessionAuthCookieSession)
 
   // Resolve the owner for the audit log before the session row is deleted.
-  const session = sessionId
-    ? await prisma.session.findUnique({
+  // Best-effort like the logging itself: a transient DB fault must not break
+  // sign-out, so fall back to an unset userId instead of throwing.
+  let userId: string | undefined
+  if (sessionId) {
+    try {
+      const session = await prisma.session.findUnique({
         select: { userId: true },
         where: { id: sessionId },
       })
-    : null
+      userId = session?.userId
+    } catch (error) {
+      console.error('Failed to resolve session owner for sign-out event', error)
+    }
+  }
 
-  recordAuthEvent({ event: 'sign_out', request, userId: session?.userId })
+  recordAuthEvent({ event: 'sign_out', request, userId })
 
   deleteSession(sessionId)
 

--- a/app/routes/administration/sign-out/utils/delete-session.server.ts
+++ b/app/routes/administration/sign-out/utils/delete-session.server.ts
@@ -1,7 +1,11 @@
 import { prisma } from '~/utils/db.server'
 
-export const deleteSession = (id: string | undefined) => {
-  void prisma.session.delete({
-    where: { id },
+// Best-effort session removal on sign-out: it must not break the response.
+// deleteMany is idempotent (no throw when the row is already gone), and any
+// transient DB error is swallowed with a log rather than becoming an unhandled
+// promise rejection.
+export const deleteSession = (id: string) => {
+  void prisma.session.deleteMany({ where: { id } }).catch((error: unknown) => {
+    console.error('Failed to delete session on sign-out', error)
   })
 }

--- a/app/utils/auth-event.server.ts
+++ b/app/utils/auth-event.server.ts
@@ -1,3 +1,4 @@
+import { setInterval } from 'node:timers'
 import { remember } from '@epic-web/remember'
 
 import { prisma } from '~/utils/db.server'

--- a/app/utils/auth-event.server.ts
+++ b/app/utils/auth-event.server.ts
@@ -1,3 +1,5 @@
+import { remember } from '@epic-web/remember'
+
 import { prisma } from '~/utils/db.server'
 import { getClientIp } from '~/utils/rate-limit.server'
 
@@ -25,6 +27,9 @@ type RecordAuthEventArgs = {
 
 // Retention window for auth events (see cleanupOldAuthEvents).
 const RETENTION_DAYS = 90
+
+// How often the retention loop prunes once running (see startAuthEventRetention).
+const RETENTION_CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000
 
 /**
  * Writes an authentication audit event. Fire-and-forget: a logging failure must
@@ -55,8 +60,8 @@ export const recordAuthEvent = ({
 }
 
 /**
- * Deletes auth events older than the retention window. Fire-and-forget; called
- * on server startup and on a daily interval (see entry.server.tsx).
+ * Deletes auth events older than the retention window. Fire-and-forget; driven
+ * by startAuthEventRetention.
  */
 export const cleanupOldAuthEvents = (): void => {
   const cutoff = new Date(Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000)
@@ -66,4 +71,22 @@ export const cleanupOldAuthEvents = (): void => {
     .catch((error: unknown) => {
       console.error('Failed to clean up old auth events', error)
     })
+}
+
+/**
+ * Starts the retention loop: prune once now, then daily. No cron mechanism
+ * exists, so this runs in-process; min_machines_running keeps a process alive so
+ * the interval fires reliably, and .unref() lets the process exit without
+ * waiting on it. remember() guards against duplicate registration when the
+ * calling module is re-evaluated (e.g. dev HMR), so exactly one interval exists
+ * per process. Called once from entry.server.
+ */
+export const startAuthEventRetention = (): void => {
+  remember('authEventRetention', () => {
+    cleanupOldAuthEvents()
+    return setInterval(
+      cleanupOldAuthEvents,
+      RETENTION_CLEANUP_INTERVAL_MS,
+    ).unref()
+  })
 }

--- a/app/utils/auth-event.server.ts
+++ b/app/utils/auth-event.server.ts
@@ -4,12 +4,6 @@ import { remember } from '@epic-web/remember'
 import { prisma } from '~/utils/db.server'
 import { getClientIp } from '~/utils/rate-limit.server'
 
-export type AuthEventName =
-  | 'sign_in_success'
-  | 'sign_in_failure'
-  | 'two_factor_failure'
-  | 'sign_out'
-
 export type AuthMethod =
   | 'password'
   | 'magic_link'
@@ -18,13 +12,21 @@ export type AuthMethod =
   | 'two_factor'
   | 'backup_code'
 
-type RecordAuthEventArgs = {
+type AuthEventBase = {
   request: Request
-  event: AuthEventName
-  method?: AuthMethod
   userId?: string
   email?: string
 }
+
+// Discriminated on `event`: the sign-in events require a `method` (a row without
+// one is incomplete), while `sign_out` has no method. This makes an incomplete
+// call a compile-time error rather than a silent bad row.
+type RecordAuthEventArgs =
+  | (AuthEventBase & {
+      event: 'sign_in_success' | 'sign_in_failure' | 'two_factor_failure'
+      method: AuthMethod
+    })
+  | (AuthEventBase & { event: 'sign_out'; method?: never })
 
 // Retention window for auth events (see cleanupOldAuthEvents).
 const RETENTION_DAYS = 90

--- a/app/utils/auth-event.server.ts
+++ b/app/utils/auth-event.server.ts
@@ -1,0 +1,69 @@
+import { prisma } from '~/utils/db.server'
+import { getClientIp } from '~/utils/rate-limit.server'
+
+export type AuthEventName =
+  | 'sign_in_success'
+  | 'sign_in_failure'
+  | 'two_factor_failure'
+  | 'sign_out'
+
+export type AuthMethod =
+  | 'password'
+  | 'magic_link'
+  | 'google'
+  | 'passkey'
+  | 'two_factor'
+  | 'backup_code'
+
+type RecordAuthEventArgs = {
+  request: Request
+  event: AuthEventName
+  method?: AuthMethod
+  userId?: string
+  email?: string
+}
+
+// Retention window for auth events (see cleanupOldAuthEvents).
+const RETENTION_DAYS = 90
+
+/**
+ * Writes an authentication audit event. Fire-and-forget: a logging failure must
+ * never break sign-in / sign-out, so the Prisma call is not awaited and any
+ * error is only console.error-ed.
+ */
+export const recordAuthEvent = ({
+  request,
+  event,
+  method,
+  userId,
+  email,
+}: RecordAuthEventArgs): void => {
+  void prisma.authEvent
+    .create({
+      data: {
+        email,
+        event,
+        ipAddress: getClientIp(request),
+        method,
+        userAgent: request.headers.get('User-Agent') ?? undefined,
+        userId,
+      },
+    })
+    .catch((error: unknown) => {
+      console.error('Failed to record auth event', error)
+    })
+}
+
+/**
+ * Deletes auth events older than the retention window. Fire-and-forget; called
+ * on server startup and on a daily interval (see entry.server.tsx).
+ */
+export const cleanupOldAuthEvents = (): void => {
+  const cutoff = new Date(Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000)
+
+  void prisma.authEvent
+    .deleteMany({ where: { createdAt: { lt: cutoff } } })
+    .catch((error: unknown) => {
+      console.error('Failed to clean up old auth events', error)
+    })
+}

--- a/app/utils/sign-in.server.ts
+++ b/app/utils/sign-in.server.ts
@@ -1,6 +1,6 @@
 import { redirect } from 'react-router'
-
 import { setSessionAuthCookieSession } from '~/utils/auth.server'
+import { type AuthMethod, recordAuthEvent } from '~/utils/auth-event.server'
 import { prisma } from '~/utils/db.server'
 import { safeRedirect } from '~/utils/safe-redirect'
 import { createSession } from '~/utils/session.server'
@@ -34,6 +34,9 @@ export const findExistingUserByEmail = async (email: string) => {
  * `headers` (optional) are merged into the redirect response — used by OAuth to
  * also clear its transient `vdm_oauth` cookie in the same response.
  *
+ * `method` identifies the sign-in method for the audit log; the successful
+ * event is recorded here once for every caller.
+ *
  * Always throws: a redirect on success, or a DB error from `createSession`
  * (which never returns normally on failure). Callers `await` it as the final
  * step; nothing after the call runs.
@@ -41,10 +44,13 @@ export const findExistingUserByEmail = async (email: string) => {
 export const signInUser = async (
   request: Request,
   userId: string,
+  method: AuthMethod,
   redirectTo?: string,
   headers?: Headers,
 ) => {
   const session = await createSession(userId)
+
+  recordAuthEvent({ event: 'sign_in_success', method, request, userId })
 
   const responseHeaders = headers ?? new Headers()
   responseHeaders.append(

--- a/prisma/migrations/20260709213937_add_auth_event/migration.sql
+++ b/prisma/migrations/20260709213937_add_auth_event/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "AuthEvent" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "event" TEXT NOT NULL,
+    "method" TEXT,
+    "userId" TEXT,
+    "email" TEXT,
+    "ipAddress" TEXT,
+    "userAgent" TEXT
+);
+
+-- CreateIndex
+CREATE INDEX "AuthEvent_createdAt_idx" ON "AuthEvent"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "AuthEvent_userId_idx" ON "AuthEvent"("userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -572,3 +572,19 @@ model Review {
 enum ReviewState {
   approved
 }
+
+// Authentication audit log. Deliberately has no relation to User so events
+// survive account deletion. `method` is nullable because sign-out has none.
+model AuthEvent {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  event     String // "sign_in_success" | "sign_in_failure" | "two_factor_failure" | "sign_out"
+  method    String? // "password" | "magic_link" | "google" | "passkey" | "two_factor" | "backup_code"
+  userId    String? // set when the user is known
+  email     String? // submitted email on failures where no user exists
+  ipAddress String?
+  userAgent String?
+
+  @@index([createdAt])
+  @@index([userId])
+}


### PR DESCRIPTION
Closes #132. Part of #126.

## Why

There was no record of authentication events. A minimal audit log answers "who signed in, when, how, and from where" and makes incidents investigable (e.g. correlating a suspicious content change with a sign-in). Scope is deliberately minimal: **write events to a DB table** — no admin UI (inspect via `pnpm prisma:studio`), no alerting.

## What

- **`AuthEvent` model** (`prisma/schema.prisma` + migration) with `@@index` on `createdAt` and `userId`. No relation to `User` so events survive account deletion. `method` is nullable — sign-out has no method (documented deviation from the issue's `String`).
- **`recordAuthEvent`** (`app/utils/auth-event.server.ts`) — fire-and-forget factory-style helper. Reuses `getClientIp` from `rate-limit.server.ts` for the client IP, reads `User-Agent` from headers, and only `console.error`s on failure so a logging fault can never break sign-in.
- **Call sites** — `signInUser` gained a `method` param and records `sign_in_success` once for magic-link / Google / passkey. The `password` and `verify-2fa` flows create sessions directly, so they record their own success (and `verify-2fa` distinguishes `two_factor` vs `backup_code`). Failure events are recorded for every method; `two_factor_failure` for bad TOTP / backup codes; `sign_out` resolves `userId` from the session before it's deleted.
- **Retention** — `cleanupOldAuthEvents` deletes events older than 90 days, run on server startup and on a daily `setInterval` in `entry.server.tsx`. No cron mechanism exists; an always-on machine (`min_machines_running=1`) keeps the interval firing. External schedulers (GitHub Actions / Google Apps Script) were rejected: they'd add a destructive endpoint outside Cloudflare for no benefit here.

## Verification

- `pnpm app:typecheck`, `pnpm test` (137 passed), Biome check — all clean; migration applies.
- Live on localhost: passkey sign-in wrote `sign_in_success` (method + userId + userAgent), a bad passkey wrote `sign_in_failure` (no userId — "credential not found" branch), and sign-out wrote `sign_out` (null method, userId resolved). `ipAddress` is `unknown` on localhost as expected — it resolves to `Fly-Client-IP` in production.