### PR TITLE
release: 2026-07-10 — auth audit log (AuthEvent)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6 # reads version from packageManager field
       - uses: actions/setup-node@v6
         with:
@@ -32,7 +32,7 @@ jobs:
     env:
       DATABASE_URL: file:./data/sqlite.db
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
@@ -47,7 +47,7 @@ jobs:
     env:
       DATABASE_URL: file:./data/sqlite.db
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
@@ -62,7 +62,7 @@ jobs:
     env:
       DATABASE_URL: file:./data/sqlite.db
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
@@ -80,7 +80,7 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v4
         id: changes
         with:
@@ -109,7 +109,7 @@ jobs:
     env:
       DATABASE_URL: file:./data/sqlite.db
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
       name: production
       url: https://vednemesicnik.cz
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: superfly/flyctl-actions/setup-flyctl@1.6
       - run: flyctl deploy --remote-only --wait-timeout 5m
         env:

--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -16,7 +16,7 @@ jobs:
   back-merge:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Open back-merge PR if dev is behind main

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -6,7 +6,6 @@
  * For more information, see https://remix.run/file-conventions/entry.server
  */
 
-import { randomBytes } from 'node:crypto'
 import { PassThrough } from 'node:stream'
 
 import { createReadableStreamFromReadable } from '@react-router/node'
@@ -26,26 +25,6 @@ export const streamTimeout = 5000
 initEnv()
 global.ENV = getEnv()
 
-// Single source of the full Content-Security-Policy, parameterised by the
-// per-request nonce that authorises React Router's inline hydration script.
-// `style-src 'unsafe-inline'` is a pragmatic start for React inline style
-// attributes; rsms.me serves the Inter font stylesheet and its woff2 files.
-function buildContentSecurityPolicy(nonce: string): string {
-  return [
-    "default-src 'self'",
-    `script-src 'self' 'nonce-${nonce}'`,
-    "style-src 'self' 'unsafe-inline' https://rsms.me",
-    "img-src 'self' data: blob:",
-    "media-src 'self'",
-    "connect-src 'self'",
-    "font-src 'self' https://rsms.me",
-    "object-src 'none'",
-    "base-uri 'self'",
-    "form-action 'self'",
-    "frame-ancestors 'none'",
-  ].join('; ')
-}
-
 export default function handleRequest(
   request: Request,
   responseStatusCode: number,
@@ -56,21 +35,13 @@ export default function handleRequest(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _loadContext: RouterContextProvider,
 ) {
-  // Per-request nonce authorising React Router's inline hydration script.
-  const nonce = randomBytes(16).toString('base64')
-
   // Baseline security headers, set once so both the bot and browser paths
   // inherit them.
   responseHeaders.set('X-Content-Type-Options', 'nosniff')
   responseHeaders.set('X-Frame-Options', 'DENY')
-  // frame-ancestors covers browsers that ignore X-Frame-Options. The full
-  // nonce-based policy ships as report-only first (#131 step 1); a follow-up
-  // PR promotes it to the enforced header.
+  // frame-ancestors covers browsers that ignore X-Frame-Options; the CSP
+  // sub-issue of #126 will extend this header value with a full policy later.
   responseHeaders.set('Content-Security-Policy', "frame-ancestors 'none'")
-  responseHeaders.set(
-    'Content-Security-Policy-Report-Only',
-    buildContentSecurityPolicy(nonce),
-  )
 
   // Route loaders may set a stricter policy (magic-link verify sends
   // `no-referrer`) — only fill in the default when none is set.
@@ -92,14 +63,12 @@ export default function handleRequest(
         responseStatusCode,
         responseHeaders,
         reactRouterContext,
-        nonce,
       )
     : handleBrowserRequest(
         request,
         responseStatusCode,
         responseHeaders,
         reactRouterContext,
-        nonce,
       )
 }
 
@@ -108,18 +77,12 @@ function handleBotRequest(
   responseStatusCode: number,
   responseHeaders: Headers,
   reactRouterContext: EntryContext,
-  nonce: string,
 ) {
   return new Promise((resolve, reject) => {
     let shellRendered = false
     const { pipe, abort } = renderToPipeableStream(
-      <ServerRouter
-        context={reactRouterContext}
-        nonce={nonce}
-        url={request.url}
-      />,
+      <ServerRouter context={reactRouterContext} url={request.url} />,
       {
-        nonce,
         onAllReady() {
           shellRendered = true
           const body = new PassThrough()
@@ -162,18 +125,12 @@ function handleBrowserRequest(
   responseStatusCode: number,
   responseHeaders: Headers,
   reactRouterContext: EntryContext,
-  nonce: string,
 ) {
   return new Promise((resolve, reject) => {
     let shellRendered = false
     const { pipe, abort } = renderToPipeableStream(
-      <ServerRouter
-        context={reactRouterContext}
-        nonce={nonce}
-        url={request.url}
-      />,
+      <ServerRouter context={reactRouterContext} url={request.url} />,
       {
-        nonce,
         onError(error: unknown) {
           responseStatusCode = 500
           // Log streaming rendering errors from inside the shell.  Don't log

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -7,7 +7,6 @@
  */
 
 import { PassThrough } from 'node:stream'
-
 import { createReadableStreamFromReadable } from '@react-router/node'
 import { isbot } from 'isbot'
 import { renderToPipeableStream } from 'react-dom/server'
@@ -17,6 +16,7 @@ import {
   ServerRouter,
 } from 'react-router'
 
+import { startAuthEventRetention } from '~/utils/auth-event.server'
 import { getEnv, initEnv } from '~/utils/env.server'
 
 // Reject/cancel all pending promises after 5 seconds
@@ -24,6 +24,9 @@ export const streamTimeout = 5000
 
 initEnv()
 global.ENV = getEnv()
+
+// Prune auth events past the retention window, once at startup and daily after.
+startAuthEventRetention()
 
 export default function handleRequest(
   request: Request,

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -6,6 +6,7 @@
  * For more information, see https://remix.run/file-conventions/entry.server
  */
 
+import { randomBytes } from 'node:crypto'
 import { PassThrough } from 'node:stream'
 
 import { createReadableStreamFromReadable } from '@react-router/node'
@@ -25,6 +26,26 @@ export const streamTimeout = 5000
 initEnv()
 global.ENV = getEnv()
 
+// Single source of the full Content-Security-Policy, parameterised by the
+// per-request nonce that authorises React Router's inline hydration script.
+// `style-src 'unsafe-inline'` is a pragmatic start for React inline style
+// attributes; rsms.me serves the Inter font stylesheet and its woff2 files.
+function buildContentSecurityPolicy(nonce: string): string {
+  return [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}'`,
+    "style-src 'self' 'unsafe-inline' https://rsms.me",
+    "img-src 'self' data: blob:",
+    "media-src 'self'",
+    "connect-src 'self'",
+    "font-src 'self' https://rsms.me",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+  ].join('; ')
+}
+
 export default function handleRequest(
   request: Request,
   responseStatusCode: number,
@@ -35,13 +56,21 @@ export default function handleRequest(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _loadContext: RouterContextProvider,
 ) {
+  // Per-request nonce authorising React Router's inline hydration script.
+  const nonce = randomBytes(16).toString('base64')
+
   // Baseline security headers, set once so both the bot and browser paths
   // inherit them.
   responseHeaders.set('X-Content-Type-Options', 'nosniff')
   responseHeaders.set('X-Frame-Options', 'DENY')
-  // frame-ancestors covers browsers that ignore X-Frame-Options; the CSP
-  // sub-issue of #126 will extend this header value with a full policy later.
+  // frame-ancestors covers browsers that ignore X-Frame-Options. The full
+  // nonce-based policy ships as report-only first (#131 step 1); a follow-up
+  // PR promotes it to the enforced header.
   responseHeaders.set('Content-Security-Policy', "frame-ancestors 'none'")
+  responseHeaders.set(
+    'Content-Security-Policy-Report-Only',
+    buildContentSecurityPolicy(nonce),
+  )
 
   // Route loaders may set a stricter policy (magic-link verify sends
   // `no-referrer`) — only fill in the default when none is set.
@@ -63,12 +92,14 @@ export default function handleRequest(
         responseStatusCode,
         responseHeaders,
         reactRouterContext,
+        nonce,
       )
     : handleBrowserRequest(
         request,
         responseStatusCode,
         responseHeaders,
         reactRouterContext,
+        nonce,
       )
 }
 
@@ -77,12 +108,18 @@ function handleBotRequest(
   responseStatusCode: number,
   responseHeaders: Headers,
   reactRouterContext: EntryContext,
+  nonce: string,
 ) {
   return new Promise((resolve, reject) => {
     let shellRendered = false
     const { pipe, abort } = renderToPipeableStream(
-      <ServerRouter context={reactRouterContext} url={request.url} />,
+      <ServerRouter
+        context={reactRouterContext}
+        nonce={nonce}
+        url={request.url}
+      />,
       {
+        nonce,
         onAllReady() {
           shellRendered = true
           const body = new PassThrough()
@@ -125,12 +162,18 @@ function handleBrowserRequest(
   responseStatusCode: number,
   responseHeaders: Headers,
   reactRouterContext: EntryContext,
+  nonce: string,
 ) {
   return new Promise((resolve, reject) => {
     let shellRendered = false
     const { pipe, abort } = renderToPipeableStream(
-      <ServerRouter context={reactRouterContext} url={request.url} />,
+      <ServerRouter
+        context={reactRouterContext}
+        nonce={nonce}
+        url={request.url}
+      />,
       {
+        nonce,
         onError(error: unknown) {
           responseStatusCode = 500
           // Log streaming rendering errors from inside the shell.  Don't log

--- a/app/routes/administration/sign-in/google/callback/_loader.ts
+++ b/app/routes/administration/sign-in/google/callback/_loader.ts
@@ -1,8 +1,8 @@
 import { ALLOWED_EMAIL_DOMAIN } from '@constants/auth'
 import type { TokenPayload } from 'google-auth-library'
 import { redirect } from 'react-router'
-
 import { requireUnauthenticated } from '~/utils/auth.server'
+import { recordAuthEvent } from '~/utils/auth-event.server'
 import { prisma } from '~/utils/db.server'
 import {
   createGoogleOAuthClient,
@@ -33,7 +33,17 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
   // Preserve the original redirectTo across the error bounce, so retrying sign-in
   // still returns the user to where they started. (It was sanitized on the way
   // in; the sign-in loader re-validates it via safeRedirect.)
-  const failTo = (error: 'oauth' | 'domain' | 'account') => {
+  // Every failure path funnels through here, so record the audit row once in one
+  // place. `email` is only known past the domain check; earlier OAuth-stage
+  // failures (denied consent, bad state/nonce, token exchange) log without it.
+  const failTo = (error: 'oauth' | 'domain' | 'account', email?: string) => {
+    recordAuthEvent({
+      email,
+      event: 'sign_in_failure',
+      method: 'google',
+      request,
+    })
+
     const search = new URLSearchParams({ error })
     if (redirectTo) search.set('redirectTo', redirectTo)
 
@@ -101,7 +111,7 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
     email === undefined ||
     !email.endsWith(`@${ALLOWED_EMAIL_DOMAIN}`)
   ) {
-    throw failTo('domain')
+    throw failTo('domain', email)
   }
 
   try {
@@ -120,6 +130,7 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
       return await signInUser(
         request,
         connection.userId,
+        'google',
         redirectTo,
         new Headers({ 'Set-Cookie': destroyCookie }),
       )
@@ -128,7 +139,9 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
     // First OAuth sign-in for an existing account → auto-link via verified email.
     const user = await findExistingUserByEmail(email)
 
-    if (user === null) throw failTo('account')
+    if (user === null) {
+      throw failTo('account', email)
+    }
 
     await prisma.connection.create({
       data: {
@@ -141,6 +154,7 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
     return await signInUser(
       request,
       user.id,
+      'google',
       redirectTo,
       new Headers({ 'Set-Cookie': destroyCookie }),
     )

--- a/app/routes/administration/sign-in/magic-link/verify/_action.ts
+++ b/app/routes/administration/sign-in/magic-link/verify/_action.ts
@@ -1,6 +1,6 @@
 import { redirect } from 'react-router'
-
 import { requireUnauthenticated } from '~/utils/auth.server'
+import { recordAuthEvent } from '~/utils/auth-event.server'
 import { checkHoneypot } from '~/utils/honeypot.server'
 import { consumeMagicLinkToken } from '~/utils/magic-link.server'
 import { findExistingUserByEmail, signInUser } from '~/utils/sign-in.server'
@@ -29,6 +29,12 @@ export const action = async ({ request }: Route.ActionArgs) => {
   const isValid = await consumeMagicLinkToken(normalizedEmail, token)
 
   if (!isValid) {
+    recordAuthEvent({
+      email: normalizedEmail,
+      event: 'sign_in_failure',
+      method: 'magic_link',
+      request,
+    })
     throw redirect('/administration/sign-in/magic-link', { status: 303 })
   }
 
@@ -36,9 +42,15 @@ export const action = async ({ request }: Route.ActionArgs) => {
 
   // The account may have been removed between request and click.
   if (user === null) {
+    recordAuthEvent({
+      email: normalizedEmail,
+      event: 'sign_in_failure',
+      method: 'magic_link',
+      request,
+    })
     throw redirect('/administration/sign-in', { status: 303 })
   }
 
   // Always throws: a redirect to /administration on success.
-  return await signInUser(request, user.id)
+  return await signInUser(request, user.id, 'magic_link')
 }

--- a/app/routes/administration/sign-in/passkey/verify-authentication-response/_action.ts
+++ b/app/routes/administration/sign-in/passkey/verify-authentication-response/_action.ts
@@ -1,6 +1,7 @@
 import { verifyAuthenticationResponse } from '@simplewebauthn/server'
 import { type ActionFunctionArgs, data } from 'react-router'
 
+import { recordAuthEvent } from '~/utils/auth-event.server'
 import {
   deleteBiometricCookieSession,
   getBiometricChallenge,
@@ -29,24 +30,50 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   })
 
   if (passkey === null) {
+    recordAuthEvent({ event: 'sign_in_failure', method: 'passkey', request })
     return data({ status: 'fail', verified: false }, { status: 400 })
   }
 
-  const verifiedAuthenticationResponse = await verifyAuthenticationResponse({
-    credential: {
-      counter: Number(passkey.credentialCounter),
-      id: passkey.credentialId,
-      publicKey: passkey.credentialPublicKey,
-      transports: JSON.parse(passkey.credentialTransports),
-    },
-    expectedChallenge: biometricChallenge ?? '',
-    expectedOrigin: process.env.RELYING_PARTY_ORIGIN ?? '',
-    expectedRPID: process.env.RELYING_PARTY_ID ?? '',
-    requireUserVerification: true,
-    response: body,
-  })
+  let verifiedAuthenticationResponse: Awaited<
+    ReturnType<typeof verifyAuthenticationResponse>
+  >
+  try {
+    verifiedAuthenticationResponse = await verifyAuthenticationResponse({
+      credential: {
+        counter: Number(passkey.credentialCounter),
+        id: passkey.credentialId,
+        publicKey: passkey.credentialPublicKey,
+        transports: JSON.parse(passkey.credentialTransports),
+      },
+      expectedChallenge: biometricChallenge ?? '',
+      expectedOrigin: process.env.RELYING_PARTY_ORIGIN ?? '',
+      expectedRPID: process.env.RELYING_PARTY_ID ?? '',
+      requireUserVerification: true,
+      response: body,
+    })
+  } catch (error) {
+    // A malformed client payload / unexpected WebAuthn response throws here;
+    // treat it as a failed attempt rather than a 500 so it is audited too.
+    console.error(
+      '[passkey] authentication response verification failed',
+      error,
+    )
+    recordAuthEvent({
+      event: 'sign_in_failure',
+      method: 'passkey',
+      request,
+      userId: passkey.userId,
+    })
+    return data({ status: 'fail', verified: false }, { status: 400 })
+  }
 
   if (!verifiedAuthenticationResponse.verified) {
+    recordAuthEvent({
+      event: 'sign_in_failure',
+      method: 'passkey',
+      request,
+      userId: passkey.userId,
+    })
     return data({ status: 'fail', verified: false }, { status: 400 })
   }
 
@@ -65,5 +92,11 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     'Set-Cookie': await deleteBiometricCookieSession(biometricCookieSession),
   })
 
-  return await signInUser(request, passkey.userId, redirectTo, headers)
+  return await signInUser(
+    request,
+    passkey.userId,
+    'passkey',
+    redirectTo,
+    headers,
+  )
 }

--- a/app/routes/administration/sign-in/password/_action.ts
+++ b/app/routes/administration/sign-in/password/_action.ts
@@ -1,8 +1,8 @@
 import { parseWithZod } from '@conform-to/zod/v4'
 import bcrypt from 'bcryptjs'
 import { data, redirect } from 'react-router'
-
 import { setSessionAuthCookieSession } from '~/utils/auth.server'
+import { recordAuthEvent } from '~/utils/auth-event.server'
 import { prisma } from '~/utils/db.server'
 import { formatRetryAfter } from '~/utils/format-retry-after'
 import { checkHoneypot } from '~/utils/honeypot.server'
@@ -81,13 +81,29 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
     where: { email },
   })
 
-  if (user !== null && user.password !== null) {
-    const isValid = await bcrypt.compare(password, user.password.hash)
+  // Capture the id up front: `user` is nulled on a wrong password below, but a
+  // failed attempt against a known account is worth correlating by userId.
+  const existingUserId = user?.id
+
+  if (user !== null) {
+    // An account without a password hash (e.g. OAuth/passkey-only) must not be
+    // signed in via this path: treat a missing hash as an invalid attempt
+    // instead of skipping the check and authenticating with any password.
+    const isValid =
+      user.password !== null &&
+      (await bcrypt.compare(password, user.password.hash))
 
     user = isValid ? user : null
   }
 
   if (user === null) {
+    recordAuthEvent({
+      email,
+      event: 'sign_in_failure',
+      method: 'password',
+      request,
+      userId: existingUserId,
+    })
     return data(
       {
         authenticationOptions: null,
@@ -119,6 +135,13 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
   }
 
   const session = await createSession(user.id)
+
+  recordAuthEvent({
+    event: 'sign_in_success',
+    method: 'password',
+    request,
+    userId: user.id,
+  })
 
   throw redirect('/administration', {
     headers: {

--- a/app/routes/administration/sign-in/verify-2fa/_action.ts
+++ b/app/routes/administration/sign-in/verify-2fa/_action.ts
@@ -1,7 +1,7 @@
 import { parseWithZod } from '@conform-to/zod/v4'
 import { data, redirect } from 'react-router'
-
 import { setSessionAuthCookieSession } from '~/utils/auth.server'
+import { recordAuthEvent } from '~/utils/auth-event.server'
 import { redeemBackupCode } from '~/utils/backup-codes.server'
 import { formatRetryAfter } from '~/utils/format-retry-after'
 import { checkHoneypot } from '~/utils/honeypot.server'
@@ -81,8 +81,12 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
   // Second factor verified — create the session and clear the pending cookie.
   // 303 See Other so the browser issues a GET after this POST, matching the
   // other redirects in this flow. Shared by the TOTP and backup-code branches.
-  const succeed = async (): Promise<never> => {
+  const succeed = async (
+    method: 'two_factor' | 'backup_code',
+  ): Promise<never> => {
     const session = await createSession(userId)
+
+    recordAuthEvent({ event: 'sign_in_success', method, request, userId })
 
     const headers = new Headers()
     headers.append(
@@ -105,6 +109,13 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
   // so the user must re-enter their password. Covers both TOTP and backup-code
   // attempts, bounding brute-forcing within the cookie lifetime.
   const fail = async (field: 'backupCode' | 'code', message: string) => {
+    recordAuthEvent({
+      event: 'two_factor_failure',
+      method: field === 'backupCode' ? 'backup_code' : 'two_factor',
+      request,
+      userId,
+    })
+
     const attempts = getPendingTwoFactorAttempts(cookieSession) + 1
 
     if (attempts >= MAX_TWO_FACTOR_ATTEMPTS) {
@@ -148,7 +159,7 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
       return fail('backupCode', 'Záložní kód je neplatný nebo již byl použit.')
     }
 
-    return succeed()
+    return succeed('backup_code')
   }
 
   // The schema guarantees one field is present, so a missing backup code means a
@@ -175,5 +186,5 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
     return fail('code', 'Kód je nesprávný nebo jeho platnost vypršela.')
   }
 
-  return succeed()
+  return succeed('two_factor')
 }

--- a/app/routes/administration/sign-out/_action.ts
+++ b/app/routes/administration/sign-out/_action.ts
@@ -1,10 +1,11 @@
 import type { ActionFunctionArgs } from 'react-router'
-
 import {
   deleteSessionAuthCookieSession,
   getSessionAuthCookieSession,
   getSessionAuthId,
 } from '~/utils/auth.server'
+import { recordAuthEvent } from '~/utils/auth-event.server'
+import { prisma } from '~/utils/db.server'
 import { redirectBack } from '~/utils/redirect-back'
 
 import { deleteSession } from './utils/delete-session.server'
@@ -13,7 +14,27 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   const sessionAuthCookieSession = await getSessionAuthCookieSession(request)
   const sessionId = getSessionAuthId(sessionAuthCookieSession)
 
-  deleteSession(sessionId)
+  // Only record / delete for an actual session — a session-less POST is not a
+  // real sign-out and must not create a noisy row or delete an undefined id.
+  if (sessionId) {
+    // Resolve the owner for the audit log before the session row is deleted.
+    // Best-effort like the logging itself: a transient DB fault must not break
+    // sign-out, so fall back to an unset userId instead of throwing.
+    let userId: string | undefined
+    try {
+      const session = await prisma.session.findUnique({
+        select: { userId: true },
+        where: { id: sessionId },
+      })
+      userId = session?.userId
+    } catch (error) {
+      console.error('Failed to resolve session owner for sign-out event', error)
+    }
+
+    recordAuthEvent({ event: 'sign_out', request, userId })
+
+    deleteSession(sessionId)
+  }
 
   return redirectBack(request, {
     headers: {

--- a/app/routes/administration/sign-out/utils/delete-session.server.ts
+++ b/app/routes/administration/sign-out/utils/delete-session.server.ts
@@ -1,7 +1,11 @@
 import { prisma } from '~/utils/db.server'
 
-export const deleteSession = (id: string | undefined) => {
-  void prisma.session.delete({
-    where: { id },
+// Best-effort session removal on sign-out: it must not break the response.
+// deleteMany is idempotent (no throw when the row is already gone), and any
+// transient DB error is swallowed with a log rather than becoming an unhandled
+// promise rejection.
+export const deleteSession = (id: string) => {
+  void prisma.session.deleteMany({ where: { id } }).catch((error: unknown) => {
+    console.error('Failed to delete session on sign-out', error)
   })
 }

--- a/app/utils/auth-event.server.ts
+++ b/app/utils/auth-event.server.ts
@@ -1,0 +1,95 @@
+import { setInterval } from 'node:timers'
+import { remember } from '@epic-web/remember'
+
+import { prisma } from '~/utils/db.server'
+import { getClientIp } from '~/utils/rate-limit.server'
+
+export type AuthMethod =
+  | 'password'
+  | 'magic_link'
+  | 'google'
+  | 'passkey'
+  | 'two_factor'
+  | 'backup_code'
+
+type AuthEventBase = {
+  request: Request
+  userId?: string
+  email?: string
+}
+
+// Discriminated on `event`: the sign-in events require a `method` (a row without
+// one is incomplete), while `sign_out` has no method. This makes an incomplete
+// call a compile-time error rather than a silent bad row.
+type RecordAuthEventArgs =
+  | (AuthEventBase & {
+      event: 'sign_in_success' | 'sign_in_failure' | 'two_factor_failure'
+      method: AuthMethod
+    })
+  | (AuthEventBase & { event: 'sign_out'; method?: never })
+
+// Retention window for auth events (see cleanupOldAuthEvents).
+const RETENTION_DAYS = 90
+
+// How often the retention loop prunes once running (see startAuthEventRetention).
+const RETENTION_CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000
+
+/**
+ * Writes an authentication audit event. Fire-and-forget: a logging failure must
+ * never break sign-in / sign-out, so the Prisma call is not awaited and any
+ * error is only console.error-ed.
+ */
+export const recordAuthEvent = ({
+  request,
+  event,
+  method,
+  userId,
+  email,
+}: RecordAuthEventArgs): void => {
+  void prisma.authEvent
+    .create({
+      data: {
+        email,
+        event,
+        ipAddress: getClientIp(request),
+        method,
+        userAgent: request.headers.get('User-Agent') ?? undefined,
+        userId,
+      },
+    })
+    .catch((error: unknown) => {
+      console.error('Failed to record auth event', error)
+    })
+}
+
+/**
+ * Deletes auth events older than the retention window. Fire-and-forget; driven
+ * by startAuthEventRetention.
+ */
+export const cleanupOldAuthEvents = (): void => {
+  const cutoff = new Date(Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000)
+
+  void prisma.authEvent
+    .deleteMany({ where: { createdAt: { lt: cutoff } } })
+    .catch((error: unknown) => {
+      console.error('Failed to clean up old auth events', error)
+    })
+}
+
+/**
+ * Starts the retention loop: prune once now, then daily. No cron mechanism
+ * exists, so this runs in-process; min_machines_running keeps a process alive so
+ * the interval fires reliably, and .unref() lets the process exit without
+ * waiting on it. remember() guards against duplicate registration when the
+ * calling module is re-evaluated (e.g. dev HMR), so exactly one interval exists
+ * per process. Called once from entry.server.
+ */
+export const startAuthEventRetention = (): void => {
+  remember('authEventRetention', () => {
+    cleanupOldAuthEvents()
+    return setInterval(
+      cleanupOldAuthEvents,
+      RETENTION_CLEANUP_INTERVAL_MS,
+    ).unref()
+  })
+}

--- a/app/utils/sign-in.server.ts
+++ b/app/utils/sign-in.server.ts
@@ -1,6 +1,6 @@
 import { redirect } from 'react-router'
-
 import { setSessionAuthCookieSession } from '~/utils/auth.server'
+import { type AuthMethod, recordAuthEvent } from '~/utils/auth-event.server'
 import { prisma } from '~/utils/db.server'
 import { safeRedirect } from '~/utils/safe-redirect'
 import { createSession } from '~/utils/session.server'
@@ -34,6 +34,9 @@ export const findExistingUserByEmail = async (email: string) => {
  * `headers` (optional) are merged into the redirect response — used by OAuth to
  * also clear its transient `vdm_oauth` cookie in the same response.
  *
+ * `method` identifies the sign-in method for the audit log; the successful
+ * event is recorded here once for every caller.
+ *
  * Always throws: a redirect on success, or a DB error from `createSession`
  * (which never returns normally on failure). Callers `await` it as the final
  * step; nothing after the call runs.
@@ -41,10 +44,13 @@ export const findExistingUserByEmail = async (email: string) => {
 export const signInUser = async (
   request: Request,
   userId: string,
+  method: AuthMethod,
   redirectTo?: string,
   headers?: Headers,
 ) => {
   const session = await createSession(userId)
+
+  recordAuthEvent({ event: 'sign_in_success', method, request, userId })
 
   const responseHeaders = headers ?? new Headers()
   responseHeaders.append(

--- a/prisma/migrations/20260709213937_add_auth_event/migration.sql
+++ b/prisma/migrations/20260709213937_add_auth_event/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "AuthEvent" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "event" TEXT NOT NULL,
+    "method" TEXT,
+    "userId" TEXT,
+    "email" TEXT,
+    "ipAddress" TEXT,
+    "userAgent" TEXT
+);
+
+-- CreateIndex
+CREATE INDEX "AuthEvent_createdAt_idx" ON "AuthEvent"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "AuthEvent_userId_idx" ON "AuthEvent"("userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -572,3 +572,19 @@ model Review {
 enum ReviewState {
   approved
 }
+
+// Authentication audit log. Deliberately has no relation to User so events
+// survive account deletion. `method` is nullable because sign-out has none.
+model AuthEvent {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  event     String // "sign_in_success" | "sign_in_failure" | "two_factor_failure" | "sign_out"
+  method    String? // "password" | "magic_link" | "google" | "passkey" | "two_factor" | "backup_code"
+  userId    String? // set when the user is known
+  email     String? // submitted email on failures where no user exists
+  ipAddress String?
+  userAgent String?
+
+  @@index([createdAt])
+  @@index([userId])
+}


### PR DESCRIPTION
Release `dev → main`. Merge with a **merge commit** (not squash) to keep histories converged.

## Ships in this release

- **feat(security): authentication audit log (AuthEvent) (#132)** — new `AuthEvent` Prisma model + migration `20260709213937_add_auth_event`, `app/utils/auth-event.server.ts`, and event logging wired into sign-in / sign-out / 2FA / passkey / magic-link / Google-callback flows. **Deploys a new DB table** (additive; no backfill).
- chore(deps): bump `actions/checkout` 6 → 7 (#173)
- CI/workflow tweaks (`ci.yml`, `deploy.yml`, `sync-dev.yml`)
- report-only nonce-based CSP (#182) and its revert (#184) — **net-neutral**, CSP work stays deferred.

## Deploy impact

Push to `main` triggers the Deploy workflow, which runs `prisma migrate deploy` and applies `add_auth_event` in production.

## After merge

`sync-dev.yml` opens a `main → dev` back-merge PR — merge it with a merge commit to reconverge histories.