### PR TITLE
docs: Prisma Studio on production guide + one-command wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,7 @@ Comprehensive project documentation is in the `docs/` directory:
 - `docs/_deploy-to-fly.md` - Deployment instructions
 - `docs/_manual-database-backup.md` - Database backup procedures
 - `docs/_manual-database-restore.md` - Database restore procedures
+- `docs/_prisma-studio-on-production.md` - Running Prisma Studio against the production database over a Fly tunnel
 
 ## Environment
 

--- a/docs/_prisma-studio-on-production.md
+++ b/docs/_prisma-studio-on-production.md
@@ -1,0 +1,66 @@
+# Prisma Studio on production
+
+For advanced, ad-hoc work with the production database in a GUI, run Prisma Studio
+**directly on the Fly machine** and tunnel to it locally. Everything Studio needs —
+the `prisma` CLI, `prisma/schema.prisma`, `prisma.config.ts`, and `DATABASE_URL` —
+already ships in the production image, so this requires **no application changes**.
+
+This is deliberately *not* embedded in the administration UI: Studio runs only while
+you run it and is reachable only through your authenticated Fly WireGuard tunnel, so
+there is no standing raw-SQL endpoint in production. Once you stop it, the capability
+is gone.
+
+> **Warning:** this is the live production database with no undo. Take a
+> [manual backup](_manual-database-backup.md) before making any writes, and know the
+> [restore procedure](_manual-database-restore.md). Concurrent access next to the
+> running app is safe (the database runs in WAL journal mode), but every edit is
+> instant on production.
+
+## Prerequisites
+
+An authenticated `flyctl` with a fresh SSH certificate in your agent (valid 24h;
+same setup as the [backup doc](_manual-database-backup.md#setup-do-this-once-per-session)):
+
+```shell
+fly ssh issue --agent -o <your-org-slug>
+```
+
+## 1. Start Studio on the machine (leave running)
+
+```shell
+fly ssh console --app cz-vednemesicnik --pty -C \
+  "sh -c 'cd /app && HOST=0.0.0.0 pnpm prisma:studio --port 5555 --browser none'"
+```
+
+- `--browser none` — there is no browser on the server to open.
+- `HOST=0.0.0.0` — Prisma 7's `prisma studio` has no `--hostname` flag; its server
+  binds to `process.env.HOST` and defaults to localhost-only, which `fly proxy`
+  cannot reach. The image already sets `HOST=0.0.0.0`, but keep it explicit so the
+  command doesn't depend on that.
+- Port 5555 is **not** publicly exposed — `fly.toml` only routes port 8080 through
+  the public `http_service`. Anything else is reachable solely over the org's
+  private 6PN/WireGuard network, which is exactly what `fly proxy` uses.
+
+Studio confirms with `Prisma Studio is running at: http://localhost:5555` (the URL
+refers to the machine, not your laptop — that's what the tunnel is for).
+
+## 2. Open the tunnel (second terminal, leave running)
+
+```shell
+fly proxy 5555 --app cz-vednemesicnik
+```
+
+Then open <http://localhost:5555> in your browser.
+
+## 3. Clean up
+
+`Ctrl+C` in both terminals — first the proxy, then the `fly ssh console` session
+(which terminates Studio on the machine). Nothing stays listening afterwards;
+re-running the proxy and getting a connection refusal is the confirmation.
+
+## Troubleshooting
+
+- **Connection refused through the proxy** — Studio isn't running on the machine, or
+  it bound to localhost (the `HOST=0.0.0.0` prefix was dropped from the command).
+- **`fly ssh` authentication errors** — re-issue the certificate:
+  `fly ssh issue --agent -o <your-org-slug>` (org slug from `fly orgs list`).

--- a/docs/_prisma-studio-on-production.md
+++ b/docs/_prisma-studio-on-production.md
@@ -47,7 +47,7 @@ refers to the machine, not your laptop — that's what the tunnel is for).
 ## 2. Open the tunnel (second terminal, leave running)
 
 ```shell
-fly proxy 5555 --app cz-vednemesicnik
+fly proxy 5555:5555 --app cz-vednemesicnik
 ```
 
 Then open <http://localhost:5555> in your browser.

--- a/docs/_prisma-studio-on-production.md
+++ b/docs/_prisma-studio-on-production.md
@@ -12,9 +12,9 @@ is gone.
 
 > **Warning:** this is the live production database with no undo. Take a
 > [manual backup](_manual-database-backup.md) before making any writes, and know the
-> [restore procedure](_manual-database-restore.md). Concurrent access next to the
-> running app is safe (the database runs in WAL journal mode), but every edit is
-> instant on production.
+> [restore procedure](_manual-database-restore.md). SQLite has a single writer, so
+> editing next to the running app can briefly block writes on either side — keep the
+> session short, and remember every edit is instant on production.
 
 ## Prerequisites
 

--- a/docs/_prisma-studio-on-production.md
+++ b/docs/_prisma-studio-on-production.md
@@ -25,6 +25,21 @@ same setup as the [backup doc](_manual-database-backup.md#setup-do-this-once-per
 fly ssh issue --agent -o <your-org-slug>
 ```
 
+## Quick start
+
+```shell
+pnpm prisma:studio:prod
+```
+
+This runs [`scripts/prisma-studio-prod.sh`](../scripts/prisma-studio-prod.sh),
+which starts Studio on the machine, opens the tunnel, and prints
+<http://localhost:5555>. Press `Ctrl+C` once to tear everything down — it also
+runs a remote `pkill` so Studio never orphans on the machine. Override defaults
+with `FLY_APP=… PORT=… pnpm prisma:studio:prod`.
+
+The manual steps below are the same thing done by hand — useful for
+understanding what the script does or when you need finer control.
+
 ## 1. Start Studio on the machine (leave running)
 
 ```shell

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "prisma:migrate:dev-init": "prisma migrate dev --name init --create-only",
     "prisma:migrate:reset": "prisma migrate reset",
     "prisma:studio": "prisma studio",
+    "prisma:studio:prod": "sh ./scripts/prisma-studio-prod.sh",
     "sql:generate": "sh ./scripts/sql-generate.sh",
     "storybook": "storybook dev -p 6006",
     "test": "vitest run"

--- a/scripts/prisma-studio-prod.sh
+++ b/scripts/prisma-studio-prod.sh
@@ -25,7 +25,7 @@ if [ "$PORT" -lt 1 ] || [ "$PORT" -gt 65535 ]; then
 fi
 
 cleanup() {
-  # Stop the local proxy and the ssh session…
+  # Stop the backgrounded ssh session (the foreground proxy is already exiting)…
   [ -n "$STUDIO_PID" ] && kill "$STUDIO_PID" 2>/dev/null || true
   # …then make sure Studio is really gone on the machine, TTY or not. Scope the
   # match to this port so we don't kill another admin's Studio session.
@@ -45,6 +45,15 @@ STUDIO_PID=$!
 
 # Give Studio a moment to bind before the proxy forwards to it.
 sleep 3
+
+# The ssh command is backgrounded, so under `set -e` a failed start (auth error,
+# wrong app) wouldn't stop us — we'd proxy to a dead port. Bail out instead.
+if ! kill -0 "$STUDIO_PID" 2>/dev/null; then
+  status=0
+  wait "$STUDIO_PID" || status=$?
+  echo "Studio failed to start on $APP (fly ssh exited $status)." >&2
+  exit 1
+fi
 
 echo "🔌 Tunnel open → http://localhost:$PORT  (Ctrl+C to stop)"
 fly proxy "$PORT:$PORT" --app "$APP"

--- a/scripts/prisma-studio-prod.sh
+++ b/scripts/prisma-studio-prod.sh
@@ -14,14 +14,29 @@
 APP="${FLY_APP:-cz-vednemesicnik}"
 PORT="${PORT:-5555}"
 
+# PORT is interpolated into a remotely executed shell command, so reject anything
+# non-numeric before it can break quoting or inject.
+case "$PORT" in
+  '' | *[!0-9]*) echo "PORT must be a number (1–65535), got '$PORT'." >&2; exit 1 ;;
+esac
+if [ "$PORT" -lt 1 ] || [ "$PORT" -gt 65535 ]; then
+  echo "PORT must be between 1 and 65535, got '$PORT'." >&2
+  exit 1
+fi
+
 cleanup() {
   # Stop the local proxy and the ssh session…
   [ -n "$STUDIO_PID" ] && kill "$STUDIO_PID" 2>/dev/null || true
-  # …then make sure Studio is really gone on the machine, TTY or not.
-  fly ssh console --app "$APP" -C "pkill -f 'prisma studio'" >/dev/null 2>&1 || true
+  # …then make sure Studio is really gone on the machine, TTY or not. Scope the
+  # match to this port so we don't kill another admin's Studio session.
+  fly ssh console --app "$APP" -C "pkill -f 'prisma studio --port $PORT'" >/dev/null 2>&1 || true
   echo "🧹 Stopped Prisma Studio and closed the tunnel."
 }
-trap cleanup EXIT INT TERM
+# `0` (not EXIT) is the portable exit-trap condition for POSIX /bin/sh (dash);
+# INT/TERM re-exit so cleanup runs exactly once, on the way out.
+trap cleanup 0
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 echo "🚀 Starting Prisma Studio on $APP (port $PORT, not publicly exposed)…"
 fly ssh console --app "$APP" -C \

--- a/scripts/prisma-studio-prod.sh
+++ b/scripts/prisma-studio-prod.sh
@@ -1,0 +1,35 @@
+#!/bin/sh -e
+
+# Runs Prisma Studio against the production database over a Fly tunnel.
+# Starts Studio on the Fly machine, opens a local `fly proxy` to it, and tears
+# both down on Ctrl+C (with a remote pkill so Studio never orphans on the
+# machine). See docs/_prisma-studio-on-production.md for the manual equivalent.
+#
+# Usage: pnpm prisma:studio:prod
+# Env:   FLY_APP (default cz-vednemesicnik), PORT (default 5555)
+#
+# Prerequisite: a fresh Fly SSH certificate in your agent:
+#   fly ssh issue --agent -o <your-org-slug>
+
+APP="${FLY_APP:-cz-vednemesicnik}"
+PORT="${PORT:-5555}"
+
+cleanup() {
+  # Stop the local proxy and the ssh session…
+  [ -n "$STUDIO_PID" ] && kill "$STUDIO_PID" 2>/dev/null || true
+  # …then make sure Studio is really gone on the machine, TTY or not.
+  fly ssh console --app "$APP" -C "pkill -f 'prisma studio'" >/dev/null 2>&1 || true
+  echo "🧹 Stopped Prisma Studio and closed the tunnel."
+}
+trap cleanup EXIT INT TERM
+
+echo "🚀 Starting Prisma Studio on $APP (port $PORT, not publicly exposed)…"
+fly ssh console --app "$APP" -C \
+  "sh -c 'cd /app && HOST=0.0.0.0 pnpm prisma:studio --port $PORT --browser none'" &
+STUDIO_PID=$!
+
+# Give Studio a moment to bind before the proxy forwards to it.
+sleep 3
+
+echo "🔌 Tunnel open → http://localhost:$PORT  (Ctrl+C to stop)"
+fly proxy "$PORT:$PORT" --app "$APP"


### PR DESCRIPTION
## Summary

Adds a guide and a one-command wrapper for running Prisma Studio against the **production** database over a Fly WireGuard tunnel, for advanced ad-hoc GUI work. Everything Studio needs already ships in the production image, so this requires **no application changes** and leaves **no standing raw-SQL endpoint** in production (Studio is reachable only while you run it, over your authenticated `fly proxy` tunnel).

- **`docs/_prisma-studio-on-production.md`** — the guide: prerequisites, a Quick start, the manual equivalent (start Studio on the machine → open the tunnel → clean up), and troubleshooting.
- **`scripts/prisma-studio-prod.sh`** + **`pnpm prisma:studio:prod`** — one command that starts Studio on the machine, opens the tunnel, prints `http://localhost:5555`, and tears both down on `Ctrl+C` (with a remote `pkill` so Studio never orphans on the machine). Configurable via `FLY_APP` / `PORT`.
- **`AGENTS.md`** — the doc added to the Documentation index.

## Notes

- A prominent warning links to the existing backup/restore procedures before any writes.
- Relative links to the backup/restore docs (and the `#setup-do-this-once-per-session` anchor) verified to resolve.
- Script wired as `sh ./scripts/...` and shipped executable (`100755`), matching the existing `scripts/` convention.

## Test plan

- [x] `pnpm test` / typecheck pass (pre-push hooks)
- [x] `sh -n scripts/prisma-studio-prod.sh` passes
- [x] Manual smoke test against Fly — verified working end-to-end