### PR TITLE
fix(editorial-board): Czech member collation + sync sheet guide

### DIFF
--- a/app/utils/editorial-board.server.test.ts
+++ b/app/utils/editorial-board.server.test.ts
@@ -69,6 +69,32 @@ describe('getEditorialBoard', () => {
     expect(JSON.parse(init.body)).toEqual({ secret: GAS_SECRET })
   })
 
+  test('orders each section members by Czech collation', async () => {
+    // Sheet order, mixing diacritics: cs collation must place Č after C and Ž
+    // last — a naive code-unit sort would order Č/Ž after all ASCII letters.
+    const unordered = {
+      ok: true,
+      positions: [
+        {
+          label: 'Role A',
+          members: ['Žák', 'Dvořák', 'Čáp', 'Cimrman'],
+          order: 1,
+        },
+      ],
+    }
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse(unordered)))
+
+    const { getEditorialBoard } = createEditorialBoardSource()
+    const result = await getEditorialBoard()
+
+    expect(result?.positions[0].members).toEqual([
+      'Cimrman',
+      'Čáp',
+      'Dvořák',
+      'Žák',
+    ])
+  })
+
   test('rejects an { ok: false } response as a failure', async () => {
     vi.stubGlobal(
       'fetch',

--- a/app/utils/editorial-board.server.ts
+++ b/app/utils/editorial-board.server.ts
@@ -49,6 +49,19 @@ export type EditorialBoardData = z.infer<typeof snapshotSchema>
 
 type CacheEntry = { data: EditorialBoardData; fetchedAt: number }
 
+// Czech collation for member names — built once and reused. Node ships full ICU,
+// so this yields correct Czech ordering (č/ř/š/ž), which GAS's limited Intl can't
+// guarantee; the endpoint therefore returns members in sheet order and we sort
+// here. `collator.compare` is already bound, so it can be passed straight to sort.
+const memberCollator = new Intl.Collator('cs')
+
+const sortMembers = (data: EditorialBoardData): EditorialBoardData => ({
+  positions: data.positions.map((position) => ({
+    ...position,
+    members: [...position.members].sort(memberCollator.compare),
+  })),
+})
+
 // Absolute path of the snapshot, next to the SQLite DB file. Derived from
 // DATABASE_URL (e.g. "file:./data/sqlite.db" → "./data/…json"). Returns null
 // when DATABASE_URL is unset so snapshot persistence is skipped rather than
@@ -87,7 +100,7 @@ const fetchFromGas = async (
       return null
     }
 
-    return { positions: parsed.data.positions }
+    return sortMembers({ positions: parsed.data.positions })
   } catch (error) {
     console.error('[editorial-board] GAS request threw —', error)
     return null
@@ -105,7 +118,7 @@ const readSnapshot = async (): Promise<EditorialBoardData | null> => {
     const raw = await fs.readFile(snapshotPath, 'utf8')
     const parsed = snapshotSchema.safeParse(JSON.parse(raw))
 
-    return parsed.success ? parsed.data : null
+    return parsed.success ? sortMembers(parsed.data) : null
   } catch {
     // No snapshot yet (cold start) or unreadable — nothing to fall back to.
     return null

--- a/app/utils/editorial-board.server.ts
+++ b/app/utils/editorial-board.server.ts
@@ -49,16 +49,17 @@ export type EditorialBoardData = z.infer<typeof snapshotSchema>
 
 type CacheEntry = { data: EditorialBoardData; fetchedAt: number }
 
-// Czech collation for member names — built once and reused. Node ships full ICU,
-// so this yields correct Czech ordering (č/ř/š/ž), which GAS's limited Intl can't
-// guarantee; the endpoint therefore returns members in sheet order and we sort
-// here. `collator.compare` is already bound, so it can be passed straight to sort.
-const memberCollator = new Intl.Collator('cs')
+// Czech collation for member names, resolved once at module scope. Node ships
+// full ICU, so this yields correct Czech ordering (č/ř/š/ž), which GAS's limited
+// Intl can't guarantee; the endpoint returns members in sheet order and we sort
+// here. `Intl.Collator#compare` is a bound function, cached here to avoid
+// re-reading it per position.
+const compareMembers = new Intl.Collator('cs').compare
 
 const sortMembers = (data: EditorialBoardData): EditorialBoardData => ({
   positions: data.positions.map((position) => ({
     ...position,
-    members: [...position.members].sort(memberCollator.compare),
+    members: [...position.members].sort(compareMembers),
   })),
 })
 

--- a/docs/_editorial-board-google-sheet.md
+++ b/docs/_editorial-board-google-sheet.md
@@ -40,19 +40,21 @@ have to add them by hand.
 
 `setupSpreadsheet()` builds the whole structure: both sheets with the canonical
 headers, frozen and formatted header rows, the `Role` dropdown on `Kontakty`, the
-`Aktivní` checkbox column, conditional formatting that greys out inactive members, the
-hidden `_pořadí role` sort helper, protection on the `Role` sheet, and it removes the
-leftover default sheet and any excess columns. It is safe to re-run and never deletes
-member rows.
+`Aktivní` checkbox column, conditional formatting that colour-codes rows by state
+(pastel green when active, pastel red when inactive, with a solid colour on the
+`Aktivní` cell), protection on the `Role` sheet, and it removes the leftover default
+sheet and any excess columns. It is safe to re-run and never deletes member rows.
 
 ### Two manual steps the script can't do
 
-Apps Script has no API for either, so do these once in the UI on `Kontakty!B` (`Role`):
+The Sheets API exposes neither setting ([googleapis #2676](https://github.com/googleapis/google-api-python-client/issues/2676)),
+so do these once in the UI on `Kontakty!B` (`Role`) — **Data ▸ Data validation ▸** the
+rule:
 
-- **Multi-select** — open the column's data-validation settings and enable multiple
-  selections, so a member can hold several roles (they then appear in each section on
-  the web).
-- **Chip colors** — open the dropdown editor and pick a color per role option.
+- **Multi-select** — switch the dropdown **Display style** to **Chip**, then enable
+  **Allow multiple selections**. The toggle stays greyed out until the dropdown is
+  chip-style. A member can then hold several roles and appears in each section on the web.
+- **Chip colors** — pick a color per role option in the same dropdown editor.
 
 ## 3. Reference: sheet design
 
@@ -78,14 +80,16 @@ reordered (within each sheet) without breaking the endpoint.
 | D      | `E-mail`       | text              | internal only — never returned by the endpoint               |
 | E      | `Telefon`      | text              | internal only — never returned by the endpoint               |
 | F      | `Poznámka`     | text              | internal only — never returned by the endpoint               |
-| G      | `_pořadí role` | hidden formula    | `=IFERROR(VLOOKUP(…;Role!A:C;3;0);999)` — sort helper        |
 
 Behaviour built by the script:
 
-- Conditional formatting greys a row when it has a name but `Aktivní` is unchecked, so
-  inactive members visually sink.
-- `Sort.gs` (`onEdit`) re-sorts on any `Role`/`Aktivní` change: active first, then role
-  order (the hidden helper), then name.
+- Conditional formatting colour-codes each named row by state — pastel green when active,
+  pastel red when inactive — with a solid green/red fill on the `Aktivní` cell. (The rules
+  combine their conditions with `*` rather than `AND(…,…)`: `whenFormulaSatisfied` doesn't
+  localise the argument separator, so a comma breaks the rule in a Czech-locale sheet.)
+- `Sort.gs` (`onEdit`) re-sorts on any `Aktivní` change so active members float to the
+  top. Section grouping and per-section name ordering are done in the endpoint/app, so a
+  member with several role chips needs no single sort position in the sheet.
 
 ## 4. Set the shared secret
 
@@ -140,8 +144,10 @@ instead of crashing.
 }
 ```
 
-- `positions` are sorted by `order`; roles with no active members are included with an
-  empty `members` array (the page renders "..." for them).
+- `positions` are sorted by `order`; `members` are returned in sheet row order and the
+  app sorts them by name with Czech ICU collation (`Intl.Collator('cs')` — Node has full
+  ICU, GAS doesn't). Roles with no active members are included with an empty `members`
+  array (the page renders "..." for them).
 - A bad secret or any internal failure returns `{ "ok": false }`. Apps Script's
   `ContentService` always answers HTTP 200, so `ok` is the only error signal.
 


### PR DESCRIPTION
Follow-up to #201 / epic #196. Two related editorial-board changes.

## 1. Member name collation moved into the app

GAS's V8 runtime ships **limited ICU**, so `localeCompare(…, 'cs')` there can't reliably apply Czech collation (č/ř/š/ž ordering). Node ships **full ICU**, so the app is the correct place to sort.

- **`app/utils/editorial-board.server.ts`**: a module-level `Intl.Collator('cs')` + `sortMembers()` helper, applied where the util ingests data (fetch success + snapshot read), so cache, snapshot, and every return are consistently ordered. `collator.compare` is passed straight to `sort`; members are copied before sorting (no mutation).
- **Test**: asserts `Č` after `C`, `Ž` last (a naive code-unit sort misplaces them).
- The GAS side (`SCRIPT__Editorial_Board__Contacts`, `main`) now returns members in sheet row order.

## 2. Sheet guide synced with the GAS script

`docs/_editorial-board-google-sheet.md` brought in line with the current script behaviour (all pushed to the script repo's `main` this cycle):

- Removed the deleted `_pořadí role` helper column.
- Grey-out → pastel green/red state colouring (+ note on the locale-safe `*` formulas, since `whenFormulaSatisfied` doesn't localise the argument separator).
- Sort is now `Aktivní`-only; grouping/name ordering happen in the endpoint/app.
- Spelled out the **chip-style prerequisite** for the manual multi-select step.

## Verification

- `pnpm test` (145) and `pnpm app:typecheck` green; biome clean (docs are out of biome scope).