### PR TITLE
Unify permission-denial semantics (403), fix Owner profile editing, enforce single-owner policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ All content entities (Article, Podcast, PodcastEpisode, Issue, etc.) support thr
 
 - **Member** (level 3): Can view/update own account and author profile
 - **Administrator** (level 2): Full access to users and authors except Owner accounts
-- **Owner** (level 1): Full system control including Owner role assignment
+- **Owner** (level 1): Full system control; exactly one Owner (from seed), and the Owner role cannot be assigned (single-owner policy)
 
 #### Author Roles (content management)
 

--- a/app/routes/administration/archive/add-issue/_loader.ts
+++ b/app/routes/administration/archive/add-issue/_loader.ts
@@ -1,5 +1,3 @@
-import { href } from 'react-router'
-
 import { getAuthorPermissionContext } from '~/utils/permissions/author/context/get-author-permission-context.server'
 import { requireAuthorPermission } from '~/utils/permissions/author/guards/require-author-permission.server'
 import { getAuthorsByPermission } from '~/utils/permissions/author/queries/get-authors-by-permission.server'
@@ -15,7 +13,6 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
   requireAuthorPermission(context, {
     action: 'create',
     entity: 'issue',
-    redirectTo: href('/administration/archive'),
     state: 'draft',
     targetAuthorIds: [context.authorId],
   })

--- a/app/routes/administration/archive/issue/edit-issue/_loader.ts
+++ b/app/routes/administration/archive/issue/edit-issue/_loader.ts
@@ -1,5 +1,3 @@
-import { href } from 'react-router'
-
 import { prisma } from '~/utils/db.server'
 import { getAuthorPermissionContext } from '~/utils/permissions/author/context/get-author-permission-context.server'
 import { requireAuthorPermission } from '~/utils/permissions/author/guards/require-author-permission.server'
@@ -43,7 +41,6 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
   requireAuthorPermission(context, {
     action: 'update',
     entity: 'issue',
-    redirectTo: href('/administration/archive/:issueId', { issueId: issue.id }),
     state: issue.state,
     targetAuthorIds: [issue.authorId],
   })

--- a/app/routes/administration/articles/add-article/_loader.ts
+++ b/app/routes/administration/articles/add-article/_loader.ts
@@ -1,5 +1,3 @@
-import { href } from 'react-router'
-
 import { prisma } from '~/utils/db.server'
 import { getAuthorPermissionContext } from '~/utils/permissions/author/context/get-author-permission-context.server'
 import { requireAuthorPermission } from '~/utils/permissions/author/guards/require-author-permission.server'
@@ -16,7 +14,6 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
   requireAuthorPermission(context, {
     action: 'create',
     entity: 'article',
-    redirectTo: href('/administration/articles'),
     state: 'draft',
     targetAuthorIds: [context.authorId],
   })

--- a/app/routes/administration/articles/article/edit-article/_loader.ts
+++ b/app/routes/administration/articles/article/edit-article/_loader.ts
@@ -1,4 +1,4 @@
-import { data, href } from 'react-router'
+import { data } from 'react-router'
 
 import { prisma } from '~/utils/db.server'
 import {
@@ -57,7 +57,6 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
   requireAuthorPermission(context, {
     action: 'update',
     entity: 'article',
-    redirectTo: href('/administration/articles'),
     state: article.state,
     targetAuthorIds: article.authors.map((author) => author.id),
   })

--- a/app/routes/administration/articles/categories/add-category/_loader.ts
+++ b/app/routes/administration/articles/categories/add-category/_loader.ts
@@ -1,5 +1,3 @@
-import { href } from 'react-router'
-
 import { getAuthorPermissionContext } from '~/utils/permissions/author/context/get-author-permission-context.server'
 import { requireAuthorPermission } from '~/utils/permissions/author/guards/require-author-permission.server'
 import { getAuthorsByPermission } from '~/utils/permissions/author/queries/get-authors-by-permission.server'
@@ -15,7 +13,6 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
   requireAuthorPermission(context, {
     action: 'create',
     entity: 'article_category',
-    redirectTo: href('/administration/articles/categories'),
     state: 'draft',
     targetAuthorIds: [context.authorId],
   })

--- a/app/routes/administration/articles/categories/category/edit-category/_loader.ts
+++ b/app/routes/administration/articles/categories/category/edit-category/_loader.ts
@@ -1,5 +1,3 @@
-import { href } from 'react-router'
-
 import { prisma } from '~/utils/db.server'
 import { getAuthorPermissionContext } from '~/utils/permissions/author/context/get-author-permission-context.server'
 import { requireAuthorPermission } from '~/utils/permissions/author/guards/require-author-permission.server'
@@ -32,9 +30,6 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
   requireAuthorPermission(context, {
     action: 'update',
     entity: 'article_category',
-    redirectTo: href('/administration/articles/categories/:categoryId', {
-      categoryId: category.id,
-    }),
     state: category.state,
     targetAuthorIds: [category.authorId],
   })

--- a/app/routes/administration/articles/tags/add-tag/_loader.ts
+++ b/app/routes/administration/articles/tags/add-tag/_loader.ts
@@ -1,5 +1,3 @@
-import { href } from 'react-router'
-
 import { getAuthorPermissionContext } from '~/utils/permissions/author/context/get-author-permission-context.server'
 import { requireAuthorPermission } from '~/utils/permissions/author/guards/require-author-permission.server'
 import { getAuthorsByPermission } from '~/utils/permissions/author/queries/get-authors-by-permission.server'
@@ -15,7 +13,6 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
   requireAuthorPermission(context, {
     action: 'create',
     entity: 'article_tag',
-    redirectTo: href('/administration/articles/tags'),
     state: 'draft',
     targetAuthorIds: [context.authorId],
   })

--- a/app/routes/administration/articles/tags/tag/edit-tag/_loader.ts
+++ b/app/routes/administration/articles/tags/tag/edit-tag/_loader.ts
@@ -1,4 +1,3 @@
-import { href } from 'react-router'
 import { prisma } from '~/utils/db.server'
 import { getAuthorPermissionContext } from '~/utils/permissions/author/context/get-author-permission-context.server'
 import { requireAuthorPermission } from '~/utils/permissions/author/guards/require-author-permission.server'
@@ -36,7 +35,6 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
   requireAuthorPermission(context, {
     action: 'update',
     entity: 'article_tag',
-    redirectTo: href('/administration/articles/tags/:tagId', { tagId }),
     state: tag.state,
     targetAuthorIds: [tag.authorId],
   })

--- a/app/routes/administration/podcasts/add-podcast/_loader.ts
+++ b/app/routes/administration/podcasts/add-podcast/_loader.ts
@@ -1,5 +1,3 @@
-import { href } from 'react-router'
-
 import { getAuthorPermissionContext } from '~/utils/permissions/author/context/get-author-permission-context.server'
 import { requireAuthorPermission } from '~/utils/permissions/author/guards/require-author-permission.server'
 import { getAuthorsByPermission } from '~/utils/permissions/author/queries/get-authors-by-permission.server'
@@ -15,7 +13,6 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
   requireAuthorPermission(context, {
     action: 'create',
     entity: 'podcast',
-    redirectTo: href('/administration/podcasts'),
     state: 'draft',
     targetAuthorIds: [context.authorId],
   })

--- a/app/routes/administration/podcasts/podcast/edit-podcast/_loader.ts
+++ b/app/routes/administration/podcasts/podcast/edit-podcast/_loader.ts
@@ -1,5 +1,3 @@
-import { href } from 'react-router'
-
 import { prisma } from '~/utils/db.server'
 import { getAuthorPermissionContext } from '~/utils/permissions/author/context/get-author-permission-context.server'
 import { requireAuthorPermission } from '~/utils/permissions/author/guards/require-author-permission.server'
@@ -38,9 +36,6 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
   requireAuthorPermission(context, {
     action: 'update',
     entity: 'podcast',
-    redirectTo: href('/administration/podcasts/:podcastId', {
-      podcastId: podcast.id,
-    }),
     state: podcast.state,
     targetAuthorIds: [podcast.authorId],
   })

--- a/app/routes/administration/podcasts/podcast/episodes/episode/edit-episode/_loader.ts
+++ b/app/routes/administration/podcasts/podcast/episodes/episode/edit-episode/_loader.ts
@@ -1,5 +1,3 @@
-import { href } from 'react-router'
-
 import { prisma } from '~/utils/db.server'
 import { getAuthorPermissionContext } from '~/utils/permissions/author/context/get-author-permission-context.server'
 import { requireAuthorPermission } from '~/utils/permissions/author/guards/require-author-permission.server'
@@ -31,10 +29,6 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
   requireAuthorPermission(context, {
     action: 'update',
     entity: 'podcast_episode',
-    redirectTo: href(
-      '/administration/podcasts/:podcastId/episodes/:episodeId',
-      { episodeId, podcastId },
-    ),
     state: episode.state,
     targetAuthorIds: [episode.authorId],
   })

--- a/app/routes/administration/users/add-user/_action.ts
+++ b/app/routes/administration/users/add-user/_action.ts
@@ -1,4 +1,5 @@
 import { parseWithZod } from '@conform-to/zod/v4'
+import { invariantResponse } from '@epic-web/invariant'
 import { type ActionFunctionArgs, data, href, redirect } from 'react-router'
 
 import { validateCSRF } from '~/utils/csrf.server'
@@ -33,9 +34,17 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   // Get the target role to check hierarchy
   const targetRole = await prisma.userRole.findUniqueOrThrow({
-    select: { level: true },
+    select: { level: true, name: true },
     where: { id: submission.value.roleId },
   })
+
+  // Single-owner policy: the Owner role originates from the seed and is unique,
+  // so a new user can never be created with it — even by an Owner actor.
+  invariantResponse(
+    targetRole.name !== 'owner',
+    'Roli Owner nelze přiřadit. V systému může existovat pouze jeden Owner.',
+    { status: 403 },
+  )
 
   // Check if user can create users with the specified role
   checkUserPermission(context, {

--- a/app/routes/administration/users/user/edit-user/_action.ts
+++ b/app/routes/administration/users/user/edit-user/_action.ts
@@ -63,6 +63,22 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   invariantResponse(
     !(isEditingSelf && isOwner && isChangingRole),
     'Owner nemůže změnit svou vlastní roli. V systému musí vždy existovat alespoň jeden Owner.',
+    { status: 403 },
+  )
+
+  // Single-owner policy: the Owner role originates from the seed and is unique.
+  // Reject changing the Owner's role away from owner, and reject promoting
+  // anyone else to owner — even for an Owner actor via a direct POST.
+  invariantResponse(
+    !(isOwner && newRole.name !== 'owner'),
+    'Roli Owner nelze změnit. V systému musí vždy existovat právě jeden Owner.',
+    { status: 403 },
+  )
+
+  invariantResponse(
+    !(!isOwner && newRole.name === 'owner'),
+    'Roli Owner nelze přiřadit. V systému může existovat pouze jeden Owner.',
+    { status: 403 },
   )
 
   // Check if user can update this user with their current role

--- a/app/routes/administration/users/user/edit-user/utils/update-user.ts
+++ b/app/routes/administration/users/user/edit-user/utils/update-user.ts
@@ -1,4 +1,3 @@
-import type { UserRoleName } from '@generated/prisma/enums'
 import bcrypt from 'bcryptjs'
 import { prisma } from '~/utils/db.server'
 import { throwDbError } from '~/utils/throw-db-error.server'
@@ -20,20 +19,14 @@ export const updateUser = async ({
   userId,
 }: Data) => {
   const userToUpdate = await prisma.user.findUnique({
-    select: {
-      role: {
-        select: {
-          name: true,
-        },
-      },
-    },
+    select: { id: true },
     where: { id: userId },
   })
 
-  const owner: UserRoleName = 'owner'
-
-  // Owner cannot be updated
-  if (userToUpdate === null || userToUpdate.role.name === owner) {
+  // Role changes (including the single-owner policy) are enforced in the action,
+  // where both the current and the target role are available. Here we only
+  // guard against updating a non-existent user.
+  if (userToUpdate === null) {
     throwError('Unable to update the user.')
   }
 

--- a/app/utils/permissions/author/actions/with-author-permission.server.ts
+++ b/app/utils/permissions/author/actions/with-author-permission.server.ts
@@ -45,8 +45,8 @@ export async function withAuthorPermission<T>(
 
   invariantResponse(
     hasPermission,
-    options.errorMessage ??
-      `You do not have permission to ${options.action} this ${options.entity}.`,
+    options.errorMessage ?? 'Nemáte oprávnění k této akci.',
+    { status: 403 },
   )
 
   return options.execute(context)

--- a/app/utils/permissions/author/guards/check-author-permission.server.test.ts
+++ b/app/utils/permissions/author/guards/check-author-permission.server.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest'
+
+import type { AuthorPermissionContext } from '../context/get-author-permission-context.server'
+import { checkAuthorPermission } from './check-author-permission.server'
+
+type CanResult = { hasPermission: boolean; hasOwn: boolean; hasAny: boolean }
+
+// Minimal context stub: the guard only calls `can()` and reads its result.
+const makeContext = (result: CanResult) =>
+  ({ can: () => result }) as unknown as AuthorPermissionContext
+
+describe('checkAuthorPermission', () => {
+  test('throws a 403 Response with a Czech message when denied', async () => {
+    const context = makeContext({
+      hasAny: false,
+      hasOwn: false,
+      hasPermission: false,
+    })
+
+    try {
+      checkAuthorPermission(context, { action: 'update', entity: 'article' })
+      expect.unreachable('checkAuthorPermission should have thrown')
+    } catch (error) {
+      expect(error).toBeInstanceOf(Response)
+      const response = error as Response
+      expect(response.status).toBe(403)
+      expect(await response.text()).toBe('Nemáte oprávnění k této akci.')
+    }
+  })
+
+  test('returns hasOwn/hasAny without throwing when granted', () => {
+    const context = makeContext({
+      hasAny: true,
+      hasOwn: false,
+      hasPermission: true,
+    })
+
+    expect(
+      checkAuthorPermission(context, { action: 'update', entity: 'article' }),
+    ).toEqual({ hasAny: true, hasOwn: false })
+  })
+})

--- a/app/utils/permissions/author/guards/check-author-permission.server.ts
+++ b/app/utils/permissions/author/guards/check-author-permission.server.ts
@@ -29,8 +29,8 @@ export function checkAuthorPermission(
 
   invariantResponse(
     hasPermission,
-    options.errorMessage ??
-      `You do not have permission to ${options.action} this ${options.entity}.`,
+    options.errorMessage ?? 'Nemáte oprávnění k této akci.',
+    { status: 403 },
   )
 
   return { hasAny, hasOwn }

--- a/app/utils/permissions/author/guards/require-author-permission.server.ts
+++ b/app/utils/permissions/author/guards/require-author-permission.server.ts
@@ -5,7 +5,6 @@ import type {
   AuthorPermissionEntity,
   ContentState,
 } from '@generated/prisma/enums'
-import { redirect } from 'react-router'
 
 import type { AuthorPermissionContext } from '../context/get-author-permission-context.server'
 
@@ -14,7 +13,6 @@ type RequireAuthorPermissionOptions = {
   action: AuthorPermissionAction
   state?: ContentState
   targetAuthorIds?: string[]
-  redirectTo?: string
 }
 
 export function requireAuthorPermission(
@@ -35,10 +33,9 @@ export function requireAuthorPermission(
     targetAuthorIds: options.targetAuthorIds,
   })
 
-  if (!hasPermission) {
-    // TODO: add flash message about insufficient permissions
-    throw redirect(options.redirectTo ?? '/administration')
-  }
+  invariantResponse(hasPermission, 'Nemáte oprávnění k této akci.', {
+    status: 403,
+  })
 
   return { hasAny, hasOwn }
 }

--- a/app/utils/permissions/user/actions/with-user-permission.server.ts
+++ b/app/utils/permissions/user/actions/with-user-permission.server.ts
@@ -42,8 +42,8 @@ export async function withUserPermission<T>(
 
   invariantResponse(
     hasPermission,
-    options.errorMessage ??
-      `You do not have permission to ${options.action} this ${options.entity}.`,
+    options.errorMessage ?? 'Nemáte oprávnění k této akci.',
+    { status: 403 },
   )
 
   return options.execute(context)

--- a/app/utils/permissions/user/guards/check-user-permission.server.test.ts
+++ b/app/utils/permissions/user/guards/check-user-permission.server.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'vitest'
+
+import type { UserPermissionContext } from '../context/get-user-permission-context.server'
+import { checkUserPermission } from './check-user-permission.server'
+
+type CanResult = { hasPermission: boolean; hasOwn: boolean; hasAny: boolean }
+
+// Minimal context stub: the guard only calls `can()` and reads its result.
+const makeContext = (result: CanResult) =>
+  ({ can: () => result }) as unknown as UserPermissionContext
+
+describe('checkUserPermission', () => {
+  test('throws a 403 Response with a Czech message when denied', async () => {
+    const context = makeContext({
+      hasAny: false,
+      hasOwn: false,
+      hasPermission: false,
+    })
+
+    try {
+      checkUserPermission(context, { action: 'update', entity: 'user' })
+      expect.unreachable('checkUserPermission should have thrown')
+    } catch (error) {
+      expect(error).toBeInstanceOf(Response)
+      const response = error as Response
+      expect(response.status).toBe(403)
+      expect(await response.text()).toBe('Nemáte oprávnění k této akci.')
+    }
+  })
+
+  test('uses a custom error message when provided', async () => {
+    const context = makeContext({
+      hasAny: false,
+      hasOwn: false,
+      hasPermission: false,
+    })
+
+    try {
+      checkUserPermission(context, {
+        action: 'update',
+        entity: 'user',
+        errorMessage: 'Roli Owner nelze přiřadit.',
+      })
+      expect.unreachable('checkUserPermission should have thrown')
+    } catch (error) {
+      const response = error as Response
+      expect(response.status).toBe(403)
+      expect(await response.text()).toBe('Roli Owner nelze přiřadit.')
+    }
+  })
+
+  test('returns hasOwn/hasAny without throwing when granted', () => {
+    const context = makeContext({
+      hasAny: false,
+      hasOwn: true,
+      hasPermission: true,
+    })
+
+    expect(
+      checkUserPermission(context, { action: 'update', entity: 'user' }),
+    ).toEqual({ hasAny: false, hasOwn: true })
+  })
+})

--- a/app/utils/permissions/user/guards/check-user-permission.server.ts
+++ b/app/utils/permissions/user/guards/check-user-permission.server.ts
@@ -28,8 +28,8 @@ export function checkUserPermission(
 
   invariantResponse(
     hasPermission,
-    options.errorMessage ??
-      `You do not have permission to ${options.action} this ${options.entity}.`,
+    options.errorMessage ?? 'Nemáte oprávnění k této akci.',
+    { status: 403 },
   )
 
   return { hasAny, hasOwn }

--- a/docs/_user-roles-and-permissions.md
+++ b/docs/_user-roles-and-permissions.md
@@ -17,7 +17,7 @@ This documentation outlines the permissions and actions available to users in th
 
 The **level** field establishes a hierarchical authority structure for role assignment and access control:
 
-- **Level 1 (Owner)**: Highest authority - can assign any role including Owner
+- **Level 1 (Owner)**: Highest authority - can assign Administrator and Member roles; the Owner role cannot be assigned to anyone (single-owner policy)
 - **Level 2 (Administrator)**: Mid-level authority - can assign Administrator and Member roles, but NOT Owner
 - **Level 3 (Member)**: Entry level - cannot assign roles to others
 
@@ -29,7 +29,8 @@ When assigning roles, users can only assign roles with a level greater than or e
 **Examples:**
 - ✅ Administrator (level 2) can assign Administrator (level 2) or Member (level 3) roles
 - ❌ Administrator (level 2) CANNOT assign Owner (level 1) role
-- ✅ Owner (level 1) can assign any role (all levels ≥ 1)
+- ✅ Owner (level 1) can assign Administrator (level 2) or Member (level 3) roles
+- ❌ Owner (level 1) CANNOT assign the Owner role — the system has exactly one Owner (single-owner policy)
 - ❌ Member (level 3) cannot assign any roles (no administrative access)
 
 ### 👤 User Entity Permissions
@@ -42,9 +43,9 @@ When assigning roles, users can only assign roles with a level greater than or e
 |                   | update     | any        | Administrators can update accounts for all roles except for owners. |
 |                   | delete     | any        | Administrators can delete accounts for all roles except for owners. |
 | **Owner**         | view       | any        | Owners can view all user accounts.                                  |
-|                   | create     | any        | Owners can create accounts for all roles, including other owners.   |
-|                   | update     | any        | Owners can update any user account.                                 |
-|                   | delete     | any        | Owners can delete any user account, including other owners.         |
+|                   | create     | any        | Owners can create accounts for Administrator and Member roles; the Owner role cannot be assigned (single-owner policy). |
+|                   | update     | any        | Owners can update any user account (including the Owner profile), but the Owner's role cannot be changed. |
+|                   | delete     | any        | Owners can delete any user account except the sole Owner account.   |
 
 ### ✍️ Author Entity Permissions
 | **Role**          | **Action** | **Access** | **Notes**                                                |
@@ -109,9 +110,11 @@ When assigning roles, users can only assign roles with a level greater than or e
 
 - **Capabilities**:
   - Full control over all actions and entities in the system.
-  - Can assign **User roles** with level ≥ 1: Owner, Administrator, Member (all roles).
+  - Can assign **User roles** Administrator and Member; the Owner role cannot be assigned (single-owner policy).
   - Can assign **Author roles**: Coordinator, Creator, Contributor.
-  - Can create, view, update, and delete any user account or author profile.
+  - Can create, view, update, and delete user accounts and author profiles.
 - **Restrictions**:
-  - Limited to one active **Owner** at a time.
+  - Exactly one **Owner** exists, created from the database seed.
+  - The Owner role cannot be assigned to anyone, nor changed away from the Owner account (enforced server-side).
+  - The sole Owner account cannot be deleted.
 


### PR DESCRIPTION
Closes #193.

Three closely related permission fixes where docs, UI, and server disagreed. Split into three commits (A / B / C).

## A — Owner profile editing
`update-user.ts` rejected *any* update to an Owner account (name, email, password), not just role changes. Removed the blanket block; a legitimate profile update now succeeds. Role-change protection lives in the action, where both the current and target role are available.

## B — Single-owner policy (enforced server-side)
The Owner role originates from the seed and must remain unique, but a direct POST could previously assign it (`1 < 1` is false → permitted). Now rejected with **403** + Czech message:
- creating a user with the owner role is always denied;
- changing anyone *to* owner is denied;
- changing the Owner's role *away from* owner is denied — even for an Owner actor.

Docs corrected: `docs/_user-roles-and-permissions.md` and `AGENTS.md` no longer claim the Owner can appoint other Owners.

## C — Unified denial semantics (403)
Permission-denied guards used `invariantResponse` without a status → HTTP **400** (library default), semantically wrong for authorization.
- `check-user` / `check-author` / `with-user` / `with-author` guards now pass `{ status: 403 }` and a Czech message (`Nemáte oprávnění k této akci.`). The target-validation invariant in `with-author` stays 400.
- `require-author-permission` converted from a silent redirect to `/administration` into a 403; removed the now-unused `redirectTo` option, its 11 call sites, and orphaned `href` imports.

## Tests
- New unit tests for the check guards: denied → 403 with the Czech message, granted → returns `hasOwn`/`hasAny`.
- `pnpm test` (164 tests) and `pnpm app:typecheck` pass under Node 26.

## Acceptance criteria
- [x] Owner can change own name/email/password; changing the Owner's role away from `owner` is rejected server-side.
- [x] A direct POST assigning the `owner` role (create or edit) is rejected with 403 even for an Owner actor; docs describe the single-owner policy accurately.
- [x] Every permission denial returns 403 (no 400s, no silent redirects on denial).
- [x] `pnpm test` and `pnpm app:typecheck` pass.