### PR TITLE
feat(audit): add AuditLog and rename AuthEvent to AuthLog (#194)

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -16,7 +16,7 @@ import {
   ServerRouter,
 } from 'react-router'
 
-import { startAuthEventRetention } from '~/utils/auth-event.server'
+import { startAuthLogRetention } from '~/utils/auth-log.server'
 import { getEnv, initEnv } from '~/utils/env.server'
 
 // Reject/cancel all pending promises after 5 seconds
@@ -26,7 +26,7 @@ initEnv()
 global.ENV = getEnv()
 
 // Prune auth events past the retention window, once at startup and daily after.
-startAuthEventRetention()
+startAuthLogRetention()
 
 export default function handleRequest(
   request: Request,

--- a/app/routes/administration/authors/author/edit-author/_action.ts
+++ b/app/routes/administration/authors/author/edit-author/_action.ts
@@ -35,20 +35,14 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     entities: ['author'],
   })
 
-  // Get the author (ownership check) and the new role, to audit role changes
-  const [author, newRole] = await Promise.all([
-    prisma.author.findUniqueOrThrow({
-      select: {
-        role: { select: { name: true } },
-        user: { select: { id: true } },
-      },
-      where: { id: submission.value.authorId },
-    }),
-    prisma.authorRole.findUniqueOrThrow({
-      select: { name: true },
-      where: { id: submission.value.roleId },
-    }),
-  ])
+  // Get the author to check ownership; keep the current role to audit changes.
+  const author = await prisma.author.findUniqueOrThrow({
+    select: {
+      role: { select: { id: true, name: true } },
+      user: { select: { id: true } },
+    },
+    where: { id: submission.value.authorId },
+  })
 
   // Check if user can update this author
   checkUserPermission(context, {
@@ -59,7 +53,15 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   await updateAuthor(submission.value)
 
-  if (author.role.name !== newRole.name) {
+  // Audit only an actual role change. The new role is looked up after
+  // updateAuthor has already validated roleId, so a tampered id can't surface as
+  // a premature 500 here.
+  if (author.role.id !== submission.value.roleId) {
+    const newRole = await prisma.authorRole.findUniqueOrThrow({
+      select: { name: true },
+      where: { id: submission.value.roleId },
+    })
+
     recordAuditLog({
       actorId: context.userId,
       detail: formatRoleChangeDetail(author.role.name, newRole.name),

--- a/app/routes/administration/authors/author/edit-author/_action.ts
+++ b/app/routes/administration/authors/author/edit-author/_action.ts
@@ -1,6 +1,10 @@
 import { parseWithZod } from '@conform-to/zod/v4'
 import { type ActionFunctionArgs, data, href, redirect } from 'react-router'
 
+import {
+  formatRoleChangeDetail,
+  recordAuditLog,
+} from '~/utils/audit-log.server'
 import { validateCSRF } from '~/utils/csrf.server'
 import { prisma } from '~/utils/db.server'
 import { getStatusCodeFromSubmissionStatus } from '~/utils/get-status-code-from-submission-status'
@@ -31,13 +35,20 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     entities: ['author'],
   })
 
-  // Get the author to check ownership
-  const author = await prisma.author.findUniqueOrThrow({
-    select: {
-      user: { select: { id: true } },
-    },
-    where: { id: submission.value.authorId },
-  })
+  // Get the author (ownership check) and the new role, to audit role changes
+  const [author, newRole] = await Promise.all([
+    prisma.author.findUniqueOrThrow({
+      select: {
+        role: { select: { name: true } },
+        user: { select: { id: true } },
+      },
+      where: { id: submission.value.authorId },
+    }),
+    prisma.authorRole.findUniqueOrThrow({
+      select: { name: true },
+      where: { id: submission.value.roleId },
+    }),
+  ])
 
   // Check if user can update this author
   checkUserPermission(context, {
@@ -47,6 +58,16 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   })
 
   await updateAuthor(submission.value)
+
+  if (author.role.name !== newRole.name) {
+    recordAuditLog({
+      actorId: context.userId,
+      detail: formatRoleChangeDetail(author.role.name, newRole.name),
+      event: 'author_role_changed',
+      request,
+      targetId: submission.value.authorId,
+    })
+  }
 
   return redirect(
     href('/administration/authors/:authorId', {

--- a/app/routes/administration/sign-in/google/callback/_loader.ts
+++ b/app/routes/administration/sign-in/google/callback/_loader.ts
@@ -2,7 +2,7 @@ import { ALLOWED_EMAIL_DOMAIN } from '@constants/auth'
 import type { TokenPayload } from 'google-auth-library'
 import { redirect } from 'react-router'
 import { requireUnauthenticated } from '~/utils/auth.server'
-import { recordAuthEvent } from '~/utils/auth-event.server'
+import { recordAuthLog } from '~/utils/auth-log.server'
 import { prisma } from '~/utils/db.server'
 import {
   createGoogleOAuthClient,
@@ -37,7 +37,7 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
   // place. `email` is only known past the domain check; earlier OAuth-stage
   // failures (denied consent, bad state/nonce, token exchange) log without it.
   const failTo = (error: 'oauth' | 'domain' | 'account', email?: string) => {
-    recordAuthEvent({
+    recordAuthLog({
       email,
       event: 'sign_in_failure',
       method: 'google',

--- a/app/routes/administration/sign-in/magic-link/verify/_action.ts
+++ b/app/routes/administration/sign-in/magic-link/verify/_action.ts
@@ -1,6 +1,6 @@
 import { redirect } from 'react-router'
 import { requireUnauthenticated } from '~/utils/auth.server'
-import { recordAuthEvent } from '~/utils/auth-event.server'
+import { recordAuthLog } from '~/utils/auth-log.server'
 import { checkHoneypot } from '~/utils/honeypot.server'
 import { consumeMagicLinkToken } from '~/utils/magic-link.server'
 import { findExistingUserByEmail, signInUser } from '~/utils/sign-in.server'
@@ -29,7 +29,7 @@ export const action = async ({ request }: Route.ActionArgs) => {
   const isValid = await consumeMagicLinkToken(normalizedEmail, token)
 
   if (!isValid) {
-    recordAuthEvent({
+    recordAuthLog({
       email: normalizedEmail,
       event: 'sign_in_failure',
       method: 'magic_link',
@@ -42,7 +42,7 @@ export const action = async ({ request }: Route.ActionArgs) => {
 
   // The account may have been removed between request and click.
   if (user === null) {
-    recordAuthEvent({
+    recordAuthLog({
       email: normalizedEmail,
       event: 'sign_in_failure',
       method: 'magic_link',

--- a/app/routes/administration/sign-in/passkey/verify-authentication-response/_action.ts
+++ b/app/routes/administration/sign-in/passkey/verify-authentication-response/_action.ts
@@ -1,7 +1,7 @@
 import { verifyAuthenticationResponse } from '@simplewebauthn/server'
 import { type ActionFunctionArgs, data } from 'react-router'
 
-import { recordAuthEvent } from '~/utils/auth-event.server'
+import { recordAuthLog } from '~/utils/auth-log.server'
 import {
   deleteBiometricCookieSession,
   getBiometricChallenge,
@@ -30,7 +30,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   })
 
   if (passkey === null) {
-    recordAuthEvent({ event: 'sign_in_failure', method: 'passkey', request })
+    recordAuthLog({ event: 'sign_in_failure', method: 'passkey', request })
     return data({ status: 'fail', verified: false }, { status: 400 })
   }
 
@@ -58,7 +58,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       '[passkey] authentication response verification failed',
       error,
     )
-    recordAuthEvent({
+    recordAuthLog({
       event: 'sign_in_failure',
       method: 'passkey',
       request,
@@ -68,7 +68,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   }
 
   if (!verifiedAuthenticationResponse.verified) {
-    recordAuthEvent({
+    recordAuthLog({
       event: 'sign_in_failure',
       method: 'passkey',
       request,

--- a/app/routes/administration/sign-in/password/_action.ts
+++ b/app/routes/administration/sign-in/password/_action.ts
@@ -2,7 +2,7 @@ import { parseWithZod } from '@conform-to/zod/v4'
 import bcrypt from 'bcryptjs'
 import { data, redirect } from 'react-router'
 import { setSessionAuthCookieSession } from '~/utils/auth.server'
-import { recordAuthEvent } from '~/utils/auth-event.server'
+import { recordAuthLog } from '~/utils/auth-log.server'
 import { prisma } from '~/utils/db.server'
 import { formatRetryAfter } from '~/utils/format-retry-after'
 import { checkHoneypot } from '~/utils/honeypot.server'
@@ -97,7 +97,7 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
   }
 
   if (user === null) {
-    recordAuthEvent({
+    recordAuthLog({
       email,
       event: 'sign_in_failure',
       method: 'password',
@@ -136,7 +136,7 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
 
   const session = await createSession(user.id)
 
-  recordAuthEvent({
+  recordAuthLog({
     event: 'sign_in_success',
     method: 'password',
     request,

--- a/app/routes/administration/sign-in/verify-2fa/_action.ts
+++ b/app/routes/administration/sign-in/verify-2fa/_action.ts
@@ -1,7 +1,7 @@
 import { parseWithZod } from '@conform-to/zod/v4'
 import { data, redirect } from 'react-router'
 import { setSessionAuthCookieSession } from '~/utils/auth.server'
-import { recordAuthEvent } from '~/utils/auth-event.server'
+import { recordAuthLog } from '~/utils/auth-log.server'
 import { redeemBackupCode } from '~/utils/backup-codes.server'
 import { formatRetryAfter } from '~/utils/format-retry-after'
 import { checkHoneypot } from '~/utils/honeypot.server'
@@ -86,7 +86,7 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
   ): Promise<never> => {
     const session = await createSession(userId)
 
-    recordAuthEvent({ event: 'sign_in_success', method, request, userId })
+    recordAuthLog({ event: 'sign_in_success', method, request, userId })
 
     const headers = new Headers()
     headers.append(
@@ -109,7 +109,7 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
   // so the user must re-enter their password. Covers both TOTP and backup-code
   // attempts, bounding brute-forcing within the cookie lifetime.
   const fail = async (field: 'backupCode' | 'code', message: string) => {
-    recordAuthEvent({
+    recordAuthLog({
       event: 'two_factor_failure',
       method: field === 'backupCode' ? 'backup_code' : 'two_factor',
       request,

--- a/app/routes/administration/sign-out/_action.ts
+++ b/app/routes/administration/sign-out/_action.ts
@@ -4,7 +4,7 @@ import {
   getSessionAuthCookieSession,
   getSessionAuthId,
 } from '~/utils/auth.server'
-import { recordAuthEvent } from '~/utils/auth-event.server'
+import { recordAuthLog } from '~/utils/auth-log.server'
 import { prisma } from '~/utils/db.server'
 import { redirectBack } from '~/utils/redirect-back'
 
@@ -31,7 +31,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
       console.error('Failed to resolve session owner for sign-out event', error)
     }
 
-    recordAuthEvent({ event: 'sign_out', request, userId })
+    recordAuthLog({ event: 'sign_out', request, userId })
 
     deleteSession(sessionId)
   }

--- a/app/routes/administration/users/add-user/_action.ts
+++ b/app/routes/administration/users/add-user/_action.ts
@@ -2,6 +2,7 @@ import { parseWithZod } from '@conform-to/zod/v4'
 import { invariantResponse } from '@epic-web/invariant'
 import { type ActionFunctionArgs, data, href, redirect } from 'react-router'
 
+import { recordAuditLog } from '~/utils/audit-log.server'
 import { validateCSRF } from '~/utils/csrf.server'
 import { prisma } from '~/utils/db.server'
 import { getStatusCodeFromSubmissionStatus } from '~/utils/get-status-code-from-submission-status'
@@ -54,6 +55,13 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   })
 
   const { userId } = await createUser(submission.value)
+
+  recordAuditLog({
+    actorId: context.userId,
+    event: 'user_created',
+    request,
+    targetId: userId,
+  })
 
   return redirect(href('/administration/users/:userId', { userId }))
 }

--- a/app/routes/administration/users/user/_index/utils/delete-user.ts
+++ b/app/routes/administration/users/user/_index/utils/delete-user.ts
@@ -1,3 +1,4 @@
+import { recordAuditLog } from '~/utils/audit-log.server'
 import { checkLastOwner } from '~/utils/check-last-owner.server'
 import { prisma } from '~/utils/db.server'
 import { withUserPermission } from '~/utils/permissions/user/actions/with-user-permission.server'
@@ -11,11 +12,18 @@ export const deleteUser = (request: Request, options: Options) =>
   withUserPermission(request, {
     action: 'delete',
     entity: 'user',
-    execute: async () => {
+    execute: async (context) => {
       // Prevent deleting the last Owner in the system
       await checkLastOwner(options.id)
 
       await prisma.user.delete({ where: { id: options.id } })
+
+      recordAuditLog({
+        actorId: context.userId,
+        event: 'user_deleted',
+        request,
+        targetId: options.id,
+      })
     },
     target: options.target,
   })

--- a/app/routes/administration/users/user/edit-user/_action.ts
+++ b/app/routes/administration/users/user/edit-user/_action.ts
@@ -2,6 +2,10 @@ import { parseWithZod } from '@conform-to/zod/v4'
 import { invariantResponse } from '@epic-web/invariant'
 import { type ActionFunctionArgs, data, href, redirect } from 'react-router'
 
+import {
+  formatRoleChangeDetail,
+  recordAuditLog,
+} from '~/utils/audit-log.server'
 import { validateCSRF } from '~/utils/csrf.server'
 import { prisma } from '~/utils/db.server'
 import { getStatusCodeFromSubmissionStatus } from '~/utils/get-status-code-from-submission-status'
@@ -98,6 +102,16 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   })
 
   await updateUser(submission.value)
+
+  if (isChangingRole) {
+    recordAuditLog({
+      actorId: context.userId,
+      detail: formatRoleChangeDetail(targetUser.role.name, newRole.name),
+      event: 'user_role_changed',
+      request,
+      targetId: targetUser.id,
+    })
+  }
 
   return redirect(
     href('/administration/users/:userId', { userId: submission.value.userId }),

--- a/app/utils/audit-log.server.ts
+++ b/app/utils/audit-log.server.ts
@@ -1,7 +1,16 @@
+import type { AuditLogEvent } from '@generated/prisma/enums'
 import { prisma } from '~/utils/db.server'
 import { getClientIp } from '~/utils/rate-limit.server'
 
 export { formatRoleChangeDetail } from '~/utils/format-role-change-detail'
+
+// Split the generated enum so the union below stays in sync with the schema: a
+// role-change event carries a `detail`, the rest don't.
+type RoleChangeEvent = Extract<
+  AuditLogEvent,
+  'user_role_changed' | 'author_role_changed'
+>
+type SimpleEvent = Exclude<AuditLogEvent, RoleChangeEvent>
 
 type AuditLogBase = {
   request: Request
@@ -13,11 +22,8 @@ type AuditLogBase = {
 // change, while create/delete carry none. This makes an incomplete call a
 // compile-time error rather than a silent bad row.
 type RecordAuditLogArgs =
-  | (AuditLogBase & { event: 'user_created' | 'user_deleted'; detail?: never })
-  | (AuditLogBase & {
-      event: 'user_role_changed' | 'author_role_changed'
-      detail: string
-    })
+  | (AuditLogBase & { event: SimpleEvent; detail?: never })
+  | (AuditLogBase & { event: RoleChangeEvent; detail: string })
 
 /**
  * Writes an administrative audit log entry. Fire-and-forget: a logging failure

--- a/app/utils/audit-log.server.ts
+++ b/app/utils/audit-log.server.ts
@@ -1,0 +1,48 @@
+import { prisma } from '~/utils/db.server'
+import { getClientIp } from '~/utils/rate-limit.server'
+
+export { formatRoleChangeDetail } from '~/utils/format-role-change-detail'
+
+type AuditLogBase = {
+  request: Request
+  actorId: string // user id of the administrator performing the action
+  targetId: string // user id (or author id for author_role_changed) of the affected account
+}
+
+// Discriminated on `event`: role-change events require a `detail` describing the
+// change, while create/delete carry none. This makes an incomplete call a
+// compile-time error rather than a silent bad row.
+type RecordAuditLogArgs =
+  | (AuditLogBase & { event: 'user_created' | 'user_deleted'; detail?: never })
+  | (AuditLogBase & {
+      event: 'user_role_changed' | 'author_role_changed'
+      detail: string
+    })
+
+/**
+ * Writes an administrative audit log entry. Fire-and-forget: a logging failure
+ * must never break the underlying mutation, so the Prisma call is not awaited and
+ * any error is only console.error-ed. No retention loop — audit records are kept
+ * indefinitely.
+ */
+export const recordAuditLog = ({
+  request,
+  event,
+  actorId,
+  targetId,
+  detail,
+}: RecordAuditLogArgs): void => {
+  void prisma.auditLog
+    .create({
+      data: {
+        actorId,
+        detail,
+        event,
+        ipAddress: getClientIp(request),
+        targetId,
+      },
+    })
+    .catch((error: unknown) => {
+      console.error('Failed to record audit log', error)
+    })
+}

--- a/app/utils/auth-log.server.ts
+++ b/app/utils/auth-log.server.ts
@@ -1,18 +1,13 @@
 import { setInterval } from 'node:timers'
 import { remember } from '@epic-web/remember'
 
+import type { AuthLogEvent, AuthMethod } from '@generated/prisma/enums'
 import { prisma } from '~/utils/db.server'
 import { getClientIp } from '~/utils/rate-limit.server'
 
-export type AuthMethod =
-  | 'password'
-  | 'magic_link'
-  | 'google'
-  | 'passkey'
-  | 'two_factor'
-  | 'backup_code'
+export type { AuthMethod }
 
-type AuthEventBase = {
+type AuthLogBase = {
   request: Request
   userId?: string
   email?: string
@@ -21,32 +16,32 @@ type AuthEventBase = {
 // Discriminated on `event`: the sign-in events require a `method` (a row without
 // one is incomplete), while `sign_out` has no method. This makes an incomplete
 // call a compile-time error rather than a silent bad row.
-type RecordAuthEventArgs =
-  | (AuthEventBase & {
-      event: 'sign_in_success' | 'sign_in_failure' | 'two_factor_failure'
+type RecordAuthLogArgs =
+  | (AuthLogBase & {
+      event: Exclude<AuthLogEvent, 'sign_out'>
       method: AuthMethod
     })
-  | (AuthEventBase & { event: 'sign_out'; method?: never })
+  | (AuthLogBase & { event: 'sign_out'; method?: never })
 
-// Retention window for auth events (see cleanupOldAuthEvents).
+// Retention window for auth logs (see cleanupOldAuthLogs).
 const RETENTION_DAYS = 90
 
-// How often the retention loop prunes once running (see startAuthEventRetention).
+// How often the retention loop prunes once running (see startAuthLogRetention).
 const RETENTION_CLEANUP_INTERVAL_MS = 24 * 60 * 60 * 1000
 
 /**
- * Writes an authentication audit event. Fire-and-forget: a logging failure must
+ * Writes an authentication log entry. Fire-and-forget: a logging failure must
  * never break sign-in / sign-out, so the Prisma call is not awaited and any
  * error is only console.error-ed.
  */
-export const recordAuthEvent = ({
+export const recordAuthLog = ({
   request,
   event,
   method,
   userId,
   email,
-}: RecordAuthEventArgs): void => {
-  void prisma.authEvent
+}: RecordAuthLogArgs): void => {
+  void prisma.authLog
     .create({
       data: {
         email,
@@ -58,21 +53,21 @@ export const recordAuthEvent = ({
       },
     })
     .catch((error: unknown) => {
-      console.error('Failed to record auth event', error)
+      console.error('Failed to record auth log', error)
     })
 }
 
 /**
- * Deletes auth events older than the retention window. Fire-and-forget; driven
- * by startAuthEventRetention.
+ * Deletes auth logs older than the retention window. Fire-and-forget; driven by
+ * startAuthLogRetention.
  */
-export const cleanupOldAuthEvents = (): void => {
+export const cleanupOldAuthLogs = (): void => {
   const cutoff = new Date(Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000)
 
-  void prisma.authEvent
+  void prisma.authLog
     .deleteMany({ where: { createdAt: { lt: cutoff } } })
     .catch((error: unknown) => {
-      console.error('Failed to clean up old auth events', error)
+      console.error('Failed to clean up old auth logs', error)
     })
 }
 
@@ -84,11 +79,11 @@ export const cleanupOldAuthEvents = (): void => {
  * calling module is re-evaluated (e.g. dev HMR), so exactly one interval exists
  * per process. Called once from entry.server.
  */
-export const startAuthEventRetention = (): void => {
-  remember('authEventRetention', () => {
-    cleanupOldAuthEvents()
+export const startAuthLogRetention = (): void => {
+  remember('authLogRetention', () => {
+    cleanupOldAuthLogs()
     return setInterval(
-      cleanupOldAuthEvents,
+      cleanupOldAuthLogs,
       RETENTION_CLEANUP_INTERVAL_MS,
     ).unref()
   })

--- a/app/utils/auth-log.server.ts
+++ b/app/utils/auth-log.server.ts
@@ -7,6 +7,11 @@ import { getClientIp } from '~/utils/rate-limit.server'
 
 export type { AuthMethod }
 
+// Split the generated enum so the union below stays in sync with the schema:
+// sign-in events carry a `method`, `sign_out` doesn't.
+type SignOutEvent = Extract<AuthLogEvent, 'sign_out'>
+type SignInEvent = Exclude<AuthLogEvent, SignOutEvent>
+
 type AuthLogBase = {
   request: Request
   userId?: string
@@ -17,11 +22,8 @@ type AuthLogBase = {
 // one is incomplete), while `sign_out` has no method. This makes an incomplete
 // call a compile-time error rather than a silent bad row.
 type RecordAuthLogArgs =
-  | (AuthLogBase & {
-      event: Exclude<AuthLogEvent, 'sign_out'>
-      method: AuthMethod
-    })
-  | (AuthLogBase & { event: 'sign_out'; method?: never })
+  | (AuthLogBase & { event: SignInEvent; method: AuthMethod })
+  | (AuthLogBase & { event: SignOutEvent; method?: never })
 
 // Retention window for auth logs (see cleanupOldAuthLogs).
 const RETENTION_DAYS = 90

--- a/app/utils/format-role-change-detail.test.ts
+++ b/app/utils/format-role-change-detail.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatRoleChangeDetail } from './format-role-change-detail'
+
+describe('formatRoleChangeDetail', () => {
+  it('formats a role change as "role: <from> → <to>"', () => {
+    expect(formatRoleChangeDetail('member', 'administrator')).toBe(
+      'role: member → administrator',
+    )
+  })
+
+  it('formats an author role change', () => {
+    expect(formatRoleChangeDetail('contributor', 'coordinator')).toBe(
+      'role: contributor → coordinator',
+    )
+  })
+
+  it('handles identical values without special-casing', () => {
+    expect(formatRoleChangeDetail('member', 'member')).toBe(
+      'role: member → member',
+    )
+  })
+})

--- a/app/utils/format-role-change-detail.ts
+++ b/app/utils/format-role-change-detail.ts
@@ -1,0 +1,5 @@
+// Formats a role change for the audit log `detail` field, e.g.
+// "role: member → administrator". Kept in its own prisma-free module so it can be
+// unit-tested without importing db.server.
+export const formatRoleChangeDetail = (from: string, to: string): string =>
+  `role: ${from} → ${to}`

--- a/app/utils/sign-in.server.ts
+++ b/app/utils/sign-in.server.ts
@@ -1,6 +1,6 @@
 import { redirect } from 'react-router'
 import { setSessionAuthCookieSession } from '~/utils/auth.server'
-import { type AuthMethod, recordAuthEvent } from '~/utils/auth-event.server'
+import { type AuthMethod, recordAuthLog } from '~/utils/auth-log.server'
 import { prisma } from '~/utils/db.server'
 import { safeRedirect } from '~/utils/safe-redirect'
 import { createSession } from '~/utils/session.server'
@@ -50,7 +50,7 @@ export const signInUser = async (
 ) => {
   const session = await createSession(userId)
 
-  recordAuthEvent({ event: 'sign_in_success', method, request, userId })
+  recordAuthLog({ event: 'sign_in_success', method, request, userId })
 
   const responseHeaders = headers ?? new Headers()
   responseHeaders.append(

--- a/docs/_audit-logging.md
+++ b/docs/_audit-logging.md
@@ -1,0 +1,33 @@
+# Audit Logging
+
+The application keeps two separate log models with different characteristics and
+retention. Both deliberately have **no relation to `User`**, so records survive
+account deletion.
+
+## `AuthLog` — authentication events
+
+- **Volume:** high — every sign-in attempt (including anonymous failures) and every
+  sign-out.
+- **Retention:** 90 days, auto-pruned. An in-process retention loop
+  (`startAuthLogRetention` in `app/utils/auth-log.server.ts`, started once from
+  `app/entry.server.tsx`) prunes on startup and then daily.
+- **Written by:** `recordAuthLog(...)` — fire-and-forget; a logging failure never
+  breaks sign-in / sign-out.
+- **`event` values:** `sign_in_success`, `sign_in_failure`, `two_factor_failure`,
+  `sign_out`. Sign-in events also carry a `method`; `sign_out` does not.
+
+## `AuditLog` — administrative mutations
+
+- **Volume:** tiny — admin mutations only.
+- **Retention:** kept indefinitely. **No pruning loop** — the forensic value is
+  permanent and the size is negligible.
+- **Written by:** `recordAuditLog(...)` in `app/utils/audit-log.server.ts` — also
+  fire-and-forget; recorded only after the mutation succeeds. The actor comes from
+  the permission context.
+- **`event` values:** `user_created`, `user_deleted`, `user_role_changed`,
+  `author_role_changed`. Role-change events carry a `detail`
+  (`"role: <old> → <new>"`, via `formatRoleChangeDetail`); create/delete do not.
+- **`targetId`:** the affected user id — or the **author id** for
+  `author_role_changed`.
+
+Both models are write-only for now; there is no UI to browse them.

--- a/prisma/migrations/20260712210131_rename_auth_event_to_auth_log/migration.sql
+++ b/prisma/migrations/20260712210131_rename_auth_event_to_auth_log/migration.sql
@@ -1,0 +1,14 @@
+-- Rename AuthEvent -> AuthLog, preserving existing rows. Hand-written because
+-- Prisma would otherwise drop + recreate the table (losing rows), and SQLite has
+-- no ALTER INDEX RENAME, so the indexes are dropped and recreated under their new
+-- model-derived names. The event/method columns stay TEXT (enum conversion is a
+-- no-op at the DB level), so no data change is needed.
+
+-- RenameTable
+ALTER TABLE "AuthEvent" RENAME TO "AuthLog";
+
+-- RenameIndex (drop + recreate; SQLite lacks ALTER INDEX RENAME)
+DROP INDEX "AuthEvent_createdAt_idx";
+DROP INDEX "AuthEvent_userId_idx";
+CREATE INDEX "AuthLog_createdAt_idx" ON "AuthLog"("createdAt");
+CREATE INDEX "AuthLog_userId_idx" ON "AuthLog"("userId");

--- a/prisma/migrations/20260712210132_add_audit_log/migration.sql
+++ b/prisma/migrations/20260712210132_add_audit_log/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "AuditLog" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "event" TEXT NOT NULL,
+    "actorId" TEXT NOT NULL,
+    "targetId" TEXT NOT NULL,
+    "detail" TEXT,
+    "ipAddress" TEXT
+);
+
+-- CreateIndex
+CREATE INDEX "AuditLog_createdAt_idx" ON "AuditLog"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "AuditLog_actorId_idx" ON "AuditLog"("actorId");
+
+-- CreateIndex
+CREATE INDEX "AuditLog_targetId_idx" ON "AuditLog"("targetId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -529,13 +529,29 @@ enum ReviewState {
   approved
 }
 
-// Authentication audit log. Deliberately has no relation to User so events
-// survive account deletion. `method` is nullable because sign-out has none.
-model AuthEvent {
-  id        String   @id @default(cuid())
-  createdAt DateTime @default(now())
-  event     String // "sign_in_success" | "sign_in_failure" | "two_factor_failure" | "sign_out"
-  method    String? // "password" | "magic_link" | "google" | "passkey" | "two_factor" | "backup_code"
+enum AuthLogEvent {
+  sign_in_success
+  sign_in_failure
+  two_factor_failure
+  sign_out
+}
+
+enum AuthMethod {
+  password
+  magic_link
+  google
+  passkey
+  two_factor
+  backup_code
+}
+
+// Authentication log. Deliberately has no relation to User so events survive
+// account deletion. `method` is nullable because sign-out has none.
+model AuthLog {
+  id        String       @id @default(cuid())
+  createdAt DateTime     @default(now())
+  event     AuthLogEvent
+  method    AuthMethod? // null for sign-out
   userId    String? // set when the user is known
   email     String? // submitted email on failures where no user exists
   ipAddress String?
@@ -543,4 +559,28 @@ model AuthEvent {
 
   @@index([createdAt])
   @@index([userId])
+}
+
+enum AuditLogEvent {
+  user_created
+  user_deleted
+  user_role_changed
+  author_role_changed
+}
+
+// Administrative audit log (user management, role changes). Deliberately has no
+// relation to User so records survive account deletion. No retention pruning:
+// volume is tiny and the forensic value is permanent.
+model AuditLog {
+  id        String        @id @default(cuid())
+  createdAt DateTime      @default(now())
+  event     AuditLogEvent
+  actorId   String // user id of the administrator performing the action
+  targetId  String // user id (or author id for author_role_changed) of the affected account
+  detail    String? // e.g. "role: member → administrator"
+  ipAddress String?
+
+  @@index([createdAt])
+  @@index([actorId])
+  @@index([targetId])
 }


### PR DESCRIPTION
Closes #194. Part of #190.

## Problem

Administrative mutations — creating/deleting users and changing user/author roles — left no trace. For a role-based access system this is the main missing security control: after an incident there was no way to answer "who promoted this account and when".

## Changes

### New `AuditLog` model
- No relation to `User`, so records survive account deletion. No retention pruning (tiny volume, permanent forensic value).
- New `recordAuditLog` helper (`app/utils/audit-log.server.ts`): fire-and-forget (a logging failure never breaks the mutation), discriminated union on `event` (role-change events require `detail`, create/delete forbid it), `ipAddress` via `getClientIp`.
- Wired into the four mutation sites, recorded after the mutation succeeds (actor from the permission context):
  - `user_created` — add-user
  - `user_deleted` — inside the `withUserPermission` execute callback
  - `user_role_changed` — edit-user, only on an actual role change
  - `author_role_changed` — edit-author, only on an actual change; `targetId` is the **author id**
- Role-change `detail` is `role: <old> → <new>` via the pure `formatRoleChangeDetail` (own module, unit-tested).

### Rename `AuthEvent` → `AuthLog`
- Cosmetic (naming symmetry). Behaviour and 90-day retention unchanged; existing rows preserved via a hand-written `ALTER TABLE ... RENAME` migration (indexes dropped/recreated — SQLite has no `ALTER INDEX RENAME`).
- `recordAuthEvent`/`cleanupOldAuthEvents`/`startAuthEventRetention` renamed accordingly; all importers updated.

### Enums
- `AuthLog`/`AuditLog` string fields converted to Prisma enums (`AuthLogEvent`, `AuthMethod`, `AuditLogEvent`), matching the existing convention (`ContentState`, `ReviewState`, …). On SQLite this is a DB no-op (columns stay TEXT).

### Docs & tests
- `docs/_audit-logging.md` documents both models and their retention difference.
- Unit test for `formatRoleChangeDetail`.

## Verification

- `pnpm app:typecheck`, `pnpm test` (167 passed), `pnpm prisma:migrate:reset` + seed all clean.
- Manual end-to-end through the admin UI (logged in as Owner): create user, change user role, change author role, delete user each produced exactly one correct `AuditLog` row; an edit without a role change produced none. Confirmed the deleted user's earlier rows survive (no FK), and existing `AuthLog` rows survived the rename.

## Migration notes

Two migrations: `rename_auth_event_to_auth_log` (hand-edited, preserves rows) and `add_audit_log` (additive).